### PR TITLE
Release children when parent is changed

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/release/Reactor.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/Reactor.java
@@ -60,6 +60,12 @@ public class Reactor {
                             break;
                         }
                     }
+                    if (project.getParent() != null
+                            && (project.getParent().getGroupId().equals(module.getGroupId()) && project.getParent().getArtifactId().equals(module.getArtifactId()))) {
+                        oneOfTheDependenciesHasChanged = true;
+                        changedDependency = project.getParent().getArtifactId();
+                        break;
+                    }
                 }
                 if (oneOfTheDependenciesHasChanged) {
                     break;

--- a/src/test/java/e2e/NestedModulesTest.java
+++ b/src/test/java/e2e/NestedModulesTest.java
@@ -66,15 +66,27 @@ public class NestedModulesTest {
         assertBothReposTagged("server-module-b", expectedServerModuleBVersion, "2");
         assertBothReposTagged("server-module-c", expectedServerModuleCVersion, "2");
 
-        testProject.mvnRelease("3");
-        assertBothReposTagged("nested-project", expectedAggregatorVersion, "3");
-        assertBothReposTagged("core-utils", expectedCoreVersion, "3");
+        testProject.commitRandomFile("parent-module");
+        testProject.mvn("releaser:release");
+
+        assertBothReposNotTagged("nested-project", expectedAggregatorVersion, "2");
+        assertBothReposTagged("core-utils", expectedCoreVersion, "2");
         assertBothReposTagged("console-app", expectedAppVersion, "3");
-        assertBothReposTagged("parent-module", expectedParentVersion, "3");
-        assertBothReposTagged("server-modules", expectedServerModulesVersion, "3");
-        assertBothReposTagged("server-module-a", expectedServerModuleAVersion, "3");
+        assertBothReposTagged("parent-module", expectedParentVersion, "2");
+        assertBothReposNotTagged("server-modules", expectedServerModulesVersion, "3");
+        assertBothReposTagged("server-module-a", expectedServerModuleAVersion, "2");
         assertBothReposTagged("server-module-b", expectedServerModuleBVersion, "3");
         assertBothReposTagged("server-module-c", expectedServerModuleCVersion, "3");
+
+        testProject.mvnRelease("4");
+        assertBothReposTagged("nested-project", expectedAggregatorVersion, "4");
+        assertBothReposTagged("core-utils", expectedCoreVersion, "4");
+        assertBothReposTagged("console-app", expectedAppVersion, "4");
+        assertBothReposTagged("parent-module", expectedParentVersion, "4");
+        assertBothReposTagged("server-modules", expectedServerModulesVersion, "4");
+        assertBothReposTagged("server-module-a", expectedServerModuleAVersion, "4");
+        assertBothReposTagged("server-module-b", expectedServerModuleBVersion, "4");
+        assertBothReposTagged("server-module-c", expectedServerModuleCVersion, "4");
 
     }
 

--- a/src/test/java/e2e/SkippingUnchangedModulesTest.java
+++ b/src/test/java/e2e/SkippingUnchangedModulesTest.java
@@ -43,8 +43,8 @@ public class SkippingUnchangedModulesTest {
         assertTagExists("console-app-3.2.1");
         assertTagExists("more-utils-10.0.1");
 
-        assertThat(initialBuildOutput, oneOf(containsString("Releasing core-utils 2.0.1 as more-utils has changed")));
-        assertThat(initialBuildOutput, oneOf(containsString("Releasing console-app 3.2.1 as core-utils has changed")));
+        assertThat(initialBuildOutput, oneOf(containsString("Releasing core-utils 2.0.1 as parent-module has changed")));
+        assertThat(initialBuildOutput, oneOf(containsString("Releasing console-app 3.2.1 as parent-module has changed")));
 
         testProject.commitRandomFile("console-app").pushIt();
         List<String> output = testProject.mvnRelease("2");


### PR DESCRIPTION
When there is a change to a module, which is a parent to different modules in the same build reactor, I'd like children to be released as well.
This way when I upgrade, for example, a dependency version in parent, I'll get releases of children using updated dependency version automatically.