### PR TITLE
Ssh agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.global.server>github</github.global.server>
+        <jsch.agentproxy.version>0.0.9</jsch.agentproxy.version>
     </properties>
 
     <ciManagement>
@@ -52,6 +53,32 @@
     </developers>
 
     <dependencies>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+            <version>0.1.51</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch.agentproxy.sshagent</artifactId>
+            <version>${jsch.agentproxy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch.agentproxy.core</artifactId>
+            <version>${jsch.agentproxy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch.agentproxy.jsch</artifactId>
+            <version>${jsch.agentproxy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch.agentproxy.usocket-nc</artifactId>
+            <version>${jsch.agentproxy.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>

--- a/src/main/java/com/github/danielflower/mavenplugins/release/LocalGitRepo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/LocalGitRepo.java
@@ -39,9 +39,11 @@ public class LocalGitRepo {
             String summary = "Cannot release with uncommitted changes. Please check the following files:";
             List<String> message = new ArrayList<String>();
             message.add(summary);
+            message.add("Uncommited:");
             for (String path : status.getUncommittedChanges()) {
                 message.add(" * " + path);
             }
+            message.add("Untracked:");
             for (String path : status.getUntracked()) {
                 message.add(" * " + path);
             }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import org.eclipse.jgit.transport.JschConfigSessionFactory;
 
 /**
  * Releases the project.
@@ -106,11 +107,16 @@ public class ReleaseMojo extends AbstractMojo {
     @Parameter(alias = "modulesToRelease", property = "modulesToRelease")
     private List<String> modulesToRelease;
 
+    @Parameter(property = "disableSshAgent")
+    private boolean disableSshAgent;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Log log = getLog();
 
         try {
+            configureJsch(log);
+
             LocalGitRepo repo = LocalGitRepo.fromCurrentDir(getRemoteUrlOrNullIfNoneSet(project.getScm()));
             repo.errorIfNotClean();
 
@@ -144,6 +150,12 @@ public class ReleaseMojo extends AbstractMojo {
             printBigErrorMessageAndThrow(log, "Could not release due to a Git error",
                 asList("There was an error while accessing the Git repository. The error returned from git was:",
                     gae.getMessage(), "Stack trace:", exceptionAsString));
+        }
+    }
+
+    private void configureJsch(Log log) {
+        if(!disableSshAgent) {
+            JschConfigSessionFactory.setInstance(new SshAgentSessionFactory(log));
         }
     }
 

--- a/src/main/java/com/github/danielflower/mavenplugins/release/SshAgentSessionFactory.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/SshAgentSessionFactory.java
@@ -1,0 +1,66 @@
+package com.github.danielflower.mavenplugins.release;
+
+import com.jcraft.jsch.IdentityRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.agentproxy.AgentProxyException;
+import com.jcraft.jsch.agentproxy.Connector;
+import com.jcraft.jsch.agentproxy.RemoteIdentityRepository;
+import com.jcraft.jsch.agentproxy.USocketFactory;
+import com.jcraft.jsch.agentproxy.connector.SSHAgentConnector;
+import com.jcraft.jsch.agentproxy.usocket.NCUSocketFactory;
+import org.apache.maven.plugin.logging.Log;
+import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.OpenSshConfig;
+import org.eclipse.jgit.util.FS;
+
+
+/**
+ * SSH-Agent enabler.
+ *
+ * A JschConfigSessionFactory which sets the Preferred authentication method to Publickey,
+ * and tries to use a NetCat Socket Factory to reach a ssh-agent process via it's Unix Socket
+ * as identified by environment var SSH_AUTH_SOCK.
+ *
+ * Note that this requires the 'nc' binary installed and available on PATH!
+ *
+ * @author Johan Ström <johan@pistonlabs.com>
+ */
+public class SshAgentSessionFactory extends JschConfigSessionFactory {
+    private final Log log;
+
+    public SshAgentSessionFactory(Log log) {
+        this.log = log;
+    }
+
+    @Override
+    protected void configure(OpenSshConfig.Host host, Session sn) {
+    }
+
+    @Override
+    protected JSch createDefaultJSch(FS fs) throws JSchException {
+        Connector con = null;
+        try {
+            // TODO: add support for others as well, such as page-ant.
+            if (SSHAgentConnector.isConnectorAvailable()) {
+                USocketFactory usf = new NCUSocketFactory();
+                con = new SSHAgentConnector(usf);
+            }
+        } catch (AgentProxyException e) {
+            log.warn("Failed to connect to SSH-agent", e);
+        }
+
+        final JSch jsch = super.createDefaultJSch(fs);
+        if (con != null) {
+            JSch.setConfig("PreferredAuthentications", "publickey");
+
+            IdentityRepository identityRepository = new RemoteIdentityRepository(con);
+            jsch.setIdentityRepository(identityRepository);
+
+            log.debug("Jsch configured to use "+con.getName());
+        }
+
+        return jsch;
+    }
+}


### PR DESCRIPTION
Ssh-agent support as discussed in #2.

Adds some build&runtime-dependencies, but can be fully disabled by setting disableSshAgent.
If SSH_AUTH_SOCK is not set in env, it will also do nothing.