### PR TITLE
Added a skip switch to the release mojo

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/release/LocalGitRepo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/LocalGitRepo.java
@@ -111,8 +111,11 @@ public class LocalGitRepo {
      * @throws ValidationException if anything goes wrong
      */
     public static LocalGitRepo fromCurrentDir(String remoteUrl) throws ValidationException {
+        return fromDir(new File("."), remoteUrl);
+    }
+
+    public static LocalGitRepo fromDir(File gitDir, String remoteUrl) throws ValidationException {
         Git git;
-        File gitDir = new File(".");
         try {
             git = Git.open(gitDir);
         } catch (RepositoryNotFoundException rnfe) {

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
@@ -43,6 +43,21 @@ public class ReleaseMojo extends AbstractMojo {
 
     /**
      * <p>
+     * When set to 'true' execution of the plugin execution is skipped.
+     * </p>
+     * <p>
+     * By default, the plugin will be executed.
+     * </p>
+     * <p>
+     * This can be specified using a command line parameter ("-DskipRelease=true") or "skip"
+     * in this plugin's configuration.
+     * </p>
+     */
+    @Parameter(property = "skipRelease", defaultValue = "false")
+    private boolean skip;
+
+    /**
+     * <p>
      * The build number to use in the release version. Given a snapshot version of "1.0-SNAPSHOT"
      * and a buildNumber value of "2", the actual released version will be "1.0.2".
      * </p>
@@ -119,6 +134,11 @@ public class ReleaseMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Log log = getLog();
+
+        if(skip) {
+            log.info("Skipping plugin execution.");
+            return;
+        }
 
         try {
             configureJsch(log);


### PR DESCRIPTION
In our case we need to be able to omit individual artifacts from being released (Artificial reactor-parent coupling together a lot of separate projects to one big maven build). Usually maven plugins have a "skip" config option to prevent mojo exectution. With this patch it's possible to skip a module by adding a "skip=true" configuration parameter.
