### PR TITLE
Added support to specify custom global/user Maven-settings for release build

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseInvoker.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseInvoker.java
@@ -73,7 +73,7 @@ class ReleaseInvoker {
 		releaseProfiles = releaseProfilesOrNull;
 	}
 
-	final void skipTests(final boolean skipTests) {
+	final void setSkipTests(final boolean skipTests) {
 		this.skipTests = skipTests;
 	}
 

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseInvoker.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseInvoker.java
@@ -1,0 +1,139 @@
+package com.github.danielflower.mavenplugins.release;
+
+import static java.util.Arrays.asList;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+
+/**
+ * @author rolandhauser
+ *
+ */
+class ReleaseInvoker {
+	private final Log log;
+	private final MavenProject project;
+	private final InvocationRequest request;
+	private List<String> goals;
+	private List<String> modulesToRelease;
+	private List<String> releaseProfiles;
+
+	public ReleaseInvoker(final Log log, final MavenProject project) {
+		this(log, project, new DefaultInvocationRequest());
+	}
+
+	
+	public ReleaseInvoker(final Log log, final MavenProject project, final InvocationRequest request) {
+		this.log = log;
+		this.project = project;
+		this.request = request;
+	}
+
+	private List<String> getGoals() {
+		if (goals == null || goals.isEmpty()) {
+			goals = asList("deploy");
+		}
+		return goals;
+	}
+
+	private List<String> getModulesToRelease() {
+		return modulesToRelease == null ? Collections.<String> emptyList() : modulesToRelease;
+	}
+
+	private List<String> getReleaseProfilesOrNull() {
+		return releaseProfiles;
+	}
+
+	final void setGoals(final List<String> goalsOrNull) {
+		goals = goalsOrNull;
+	}
+
+	final void setModulesToRelease(final List<String> modulesToReleaseOrNull) {
+		modulesToRelease = modulesToReleaseOrNull;
+	}
+
+	final void setReleaseProfiles(final List<String> releaseProfilesOrNull) {
+		releaseProfiles = releaseProfilesOrNull;
+	}
+
+	final void skipTests(final boolean skipTests) {
+		if (skipTests) {
+			getGoals().add("-DskipTests=true");
+		}
+	}
+
+	final void setGlobalSettings(final File globalSettings) {
+		request.setGlobalSettingsFile(globalSettings);
+	}
+
+	final void setUserSettings(final File userSettings) {
+		request.setUserSettingsFile(userSettings);
+	}
+
+	protected InvocationRequest createRequest() {
+		return new DefaultInvocationRequest();
+	}
+
+	public final void runMavenBuild(final Reactor reactor) throws MojoExecutionException {
+		final InvocationRequest request = createRequest();
+		request.setInteractive(false);
+
+		request.setShowErrors(true);
+		request.setDebug(log.isDebugEnabled());
+		request.setGoals(getGoals());
+		final List<String> profiles = profilesToActivate();
+		request.setProfiles(profiles);
+
+		request.setAlsoMake(true);
+		final List<String> changedModules = new ArrayList<String>();
+		final List<String> modulesToRelease = getModulesToRelease();
+		for (final ReleasableModule releasableModule : reactor.getModulesInBuildOrder()) {
+			final String modulePath = releasableModule.getRelativePathToModule();
+			final boolean userExplicitlyWantsThisToBeReleased = modulesToRelease.contains(modulePath);
+			final boolean userImplicitlyWantsThisToBeReleased = modulesToRelease.isEmpty();
+			if (userExplicitlyWantsThisToBeReleased
+					|| (userImplicitlyWantsThisToBeReleased && releasableModule.willBeReleased())) {
+				changedModules.add(modulePath);
+			}
+		}
+		request.setProjects(changedModules);
+
+		final String profilesInfo = (profiles.size() == 0) ? "no profiles activated" : "profiles " + profiles;
+
+		log.info("About to run mvn " + goals + " with " + profilesInfo);
+
+		final Invoker invoker = new DefaultInvoker();
+		try {
+			final InvocationResult result = invoker.execute(request);
+			if (result.getExitCode() != 0) {
+				throw new MojoExecutionException("Maven execution returned code " + result.getExitCode());
+			}
+		} catch (final MavenInvocationException e) {
+			throw new MojoExecutionException("Failed to build artifact", e);
+		}
+	}
+
+	private List<String> profilesToActivate() {
+		final List<String> profiles = new ArrayList<String>();
+		if (getReleaseProfilesOrNull() != null) {
+			for (final String releaseProfile : getReleaseProfilesOrNull()) {
+				profiles.add(releaseProfile);
+			}
+		}
+		for (final Object activatedProfile : project.getActiveProfiles()) {
+			profiles.add(((org.apache.maven.model.Profile) activatedProfile).getId());
+		}
+		return profiles;
+	}
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
@@ -113,7 +113,7 @@ public class ReleaseMojo extends BaseMojo {
             	invoker.setGoals(goals);
             	invoker.setModulesToRelease(modulesToRelease);
             	invoker.setReleaseProfiles(releaseProfiles);
-            	invoker.skipTests(skipTests);
+            	invoker.setSkipTests(skipTests);
                 invoker.runMavenBuild(reactor);
                 revertChanges(log, repo, changedFiles, true); // throw if you can't revert as that is the root problem
             } finally {

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
@@ -113,6 +113,7 @@ public class ReleaseMojo extends BaseMojo {
             	invoker.setGoals(goals);
             	invoker.setModulesToRelease(modulesToRelease);
             	invoker.setReleaseProfiles(releaseProfiles);
+            	invoker.skipTests(skipTests);
                 invoker.runMavenBuild(reactor);
                 revertChanges(log, repo, changedFiles, true); // throw if you can't revert as that is the root problem
             } finally {

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -48,6 +48,41 @@ To do this, use the `forceRelease` parameter. For example:
 
 In this case the `MyApp` module will be built, even if there where no changes found.
 
+Specify custom global/user Maven settings for release build
+-----------------------------------------------------------
+Sometimes it's necessary to specify custom Maven settings for the release build. This can be done with the optional plugin properties 
+**globalSettings** (defaults to `$M2_HOME/conf/settings.xml`) and **userSettings** (defaults to `${user.home}/.m2/settings.xml`). 
+These properties are used to specify the path to a custom Maven settings file:
+
+	<plugin>
+		...
+		<configuration>
+			<userSettings>/path/to/my/settings.xml</userSettings>
+		</configuration>
+	</plugin>	
+
+Or
+
+	<plugin>
+		...
+		<configuration>
+			<globalSettings>/path/to/global/settings.xml</globalSettings>
+		</configuration>
+	</plugin>
+	
+Or both
+
+	<plugin>
+		...
+		<configuration>
+			<globalSettings>/path/to/global/settings.xml</globalSettings>
+			<userSettings>/path/to/my/settings.xml</userSettings>
+		</configuration>
+	</plugin>
+	
+Note: properties from user settings always _override_ those derived from global settings, see <https://maven.apache.org/settings.html#Quick_Overview>
+for further information.
+
 SSH authentication
 ------------------
 Currently, only public key authentication is supported. By default, the plugin reads the private key from `~/.ssh/id_rsa`. 

--- a/src/test/java/com/github/danielflower/mavenplugins/release/ReleaseInvokerTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/ReleaseInvokerTest.java
@@ -234,7 +234,7 @@ public class ReleaseInvokerTest {
 
 	@Test
 	public void skipTests() throws Exception {
-		releaseInvoker.skipTests(true);
+		releaseInvoker.setSkipTests(true);
 		releaseInvoker.runMavenBuild(reactor);
 		verify(request).setGoals(Mockito.argThat(new BaseMatcher<List<String>>() {
 

--- a/src/test/java/com/github/danielflower/mavenplugins/release/ReleaseInvokerTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/ReleaseInvokerTest.java
@@ -1,0 +1,272 @@
+package com.github.danielflower.mavenplugins.release;
+
+import static com.github.danielflower.mavenplugins.release.ReleaseInvoker.DEPLOY;
+import static com.github.danielflower.mavenplugins.release.ReleaseInvoker.SKIP_TESTS;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.maven.model.Profile;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Roland Hauser sourcepond@gmail.com
+ *
+ */
+public class ReleaseInvokerTest {
+	private final static String ACTIVE_PROFILE_ID = "activeProfile";
+	private final static String SOME_PROFILE_ID = "someProfile";
+	private final static File GLOBAL_SETTINGS = new File("file:///globalSettings");
+	private final static File USER_SETTINGS = new File("file:///globalSettings");
+	private final static String MODULE_PATH = "modulePath";
+	private final static String SITE = "site";
+	private final Log log = mock(Log.class);
+	private final MavenProject project = mock(MavenProject.class);
+	private final InvocationRequest request = mock(InvocationRequest.class);
+	private final InvocationResult result = mock(InvocationResult.class);
+	private final Invoker invoker = mock(Invoker.class);
+	private final List<String> goals = new LinkedList<String>();
+	private final List<String> modulesToRelease = new LinkedList<String>();
+	private final List<String> releaseProfiles = new LinkedList<String>();
+	private final List<ReleasableModule> modulesInBuildOrder = new LinkedList<ReleasableModule>();
+	private final Reactor reactor = mock(Reactor.class);
+	private final ReleasableModule module = mock(ReleasableModule.class);
+	private final Profile activeProfile = mock(Profile.class);
+	private final ReleaseInvoker releaseInvoker = new ReleaseInvoker(log, project, request, invoker);
+
+	@Before
+	public void setup() throws Exception {
+		modulesInBuildOrder.add(module);
+		when(log.isDebugEnabled()).thenReturn(true);
+		when(invoker.execute(request)).thenReturn(result);
+		when(activeProfile.getId()).thenReturn(ACTIVE_PROFILE_ID);
+		when(module.getRelativePathToModule()).thenReturn(MODULE_PATH);
+	}
+
+	@Test
+	public void verifyDefaultConstructor() {
+		new ReleaseInvoker(log, project);
+	}
+
+	@Test
+	public void runMavenBuild_BaseTest() throws Exception {
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setInteractive(false);
+		verify(request).setShowErrors(true);
+		verify(request).setDebug(true);
+		verify(log).isDebugEnabled();
+		verify(request).setAlsoMake(true);
+		verify(request).setGoals(Mockito.argThat(new BaseMatcher<List<String>>() {
+
+			@Override
+			public boolean matches(final Object item) {
+				@SuppressWarnings("unchecked")
+				final List<String> goals = (List<String>) item;
+				return goals.size() == 1 && goals.contains(DEPLOY);
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("deploy");
+			}
+		}));
+		verify(request).setProjects(Mockito.argThat(new BaseMatcher<List<String>>() {
+
+			@Override
+			@SuppressWarnings("unchecked")
+			public boolean matches(final Object item) {
+				return ((List<String>) item).isEmpty();
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("projects");
+			}
+		}));
+		verify(log).info("About to run mvn [deploy] with no profiles activated");
+	}
+
+	@Test
+	public void runMavenBuild_WithUserSettings() throws Exception {
+		releaseInvoker.setUserSettings(USER_SETTINGS);
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setUserSettingsFile(USER_SETTINGS);
+	}
+
+	@Test
+	public void runMavenBuild_WithGlobalSettings() throws Exception {
+		releaseInvoker.setGlobalSettings(GLOBAL_SETTINGS);
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setGlobalSettingsFile(GLOBAL_SETTINGS);
+	}
+
+	@Test
+	public void runMavenBuild_WithReleasableModule() throws Exception {
+		// releaseProfiles.add(e)
+	}
+
+	@Test
+	public void runMavenBuild_WithGoals() throws Exception {
+		goals.add(SITE);
+		releaseInvoker.setGoals(goals);
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setGoals(Mockito.argThat(new BaseMatcher<List<String>>() {
+
+			@Override
+			@SuppressWarnings("unchecked")
+			public boolean matches(final Object item) {
+				final List<String> goals = (List<String>) item;
+				return goals.size() == 1 && goals.contains(SITE);
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("goals");
+			}
+		}));
+	}
+
+	@Test
+	public void runMavenBuild_WithActiveProfiles() throws Exception {
+		releaseProfiles.add(SOME_PROFILE_ID);
+		releaseInvoker.setReleaseProfiles(releaseProfiles);
+		when(project.getActiveProfiles()).thenReturn(asList(activeProfile));
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setProfiles(Mockito.argThat(new BaseMatcher<List<String>>() {
+
+			@Override
+			@SuppressWarnings("unchecked")
+			public boolean matches(final Object item) {
+				final List<String> profiles = (List<String>) item;
+				return profiles.size() == 2 && profiles.contains(ACTIVE_PROFILE_ID)
+						&& profiles.contains(SOME_PROFILE_ID);
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("profiles");
+			}
+		}));
+	}
+
+	@Test
+	public void runMavenBuild_UserExplicitlyWantsThisToBeReleased() throws Exception {
+		when(reactor.getModulesInBuildOrder()).thenReturn(modulesInBuildOrder);
+		modulesToRelease.add(MODULE_PATH);
+		releaseInvoker.setModulesToRelease(modulesToRelease);
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setProjects(Mockito.argThat(new BaseMatcher<List<String>>() {
+
+			@Override
+			@SuppressWarnings("unchecked")
+			public boolean matches(final Object item) {
+				final List<String> modules = (List<String>) item;
+				return modules.size() == 1 && modules.contains(MODULE_PATH);
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("projects");
+			}
+		}));
+	}
+
+	@Test
+	public void runMavenBuild_UserImplicitlyWantsThisToBeReleased() throws Exception {
+		when(reactor.getModulesInBuildOrder()).thenReturn(modulesInBuildOrder);
+		when(module.willBeReleased()).thenReturn(true);
+		releaseInvoker.setModulesToRelease(modulesToRelease);
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setProjects(Mockito.argThat(new BaseMatcher<List<String>>() {
+
+			@Override
+			@SuppressWarnings("unchecked")
+			public boolean matches(final Object item) {
+				final List<String> modules = (List<String>) item;
+				return modules.size() == 1 && modules.contains(MODULE_PATH);
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("projects");
+			}
+		}));
+	}
+
+	@Test
+	public void runMavenBuild_UserImplicitlyWantsThisToBeReleased_WillNotBeReleased() throws Exception {
+		when(reactor.getModulesInBuildOrder()).thenReturn(modulesInBuildOrder);
+		releaseInvoker.setModulesToRelease(modulesToRelease);
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setProjects(Mockito.argThat(new BaseMatcher<List<String>>() {
+
+			@Override
+			@SuppressWarnings("unchecked")
+			public boolean matches(final Object item) {
+				return ((List<String>) item).isEmpty();
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("projects");
+			}
+		}));
+	}
+
+	@Test
+	public void skipTests() throws Exception {
+		releaseInvoker.skipTests(true);
+		releaseInvoker.runMavenBuild(reactor);
+		verify(request).setGoals(Mockito.argThat(new BaseMatcher<List<String>>() {
+
+			@Override
+			@SuppressWarnings("unchecked")
+			public boolean matches(final Object item) {
+				final List<String> goals = (List<String>) item;
+				return goals.size() == 2 && goals.contains(DEPLOY) && goals.contains(SKIP_TESTS);
+			}
+
+			@Override
+			public void describeTo(final Description description) {
+				description.appendText("goals");
+			}
+		}));
+	}
+
+	@Test(expected = MojoExecutionException.class)
+	public void runMavenBuild_ErrorExitCode() throws Exception {
+		when(result.getExitCode()).thenReturn(1);
+		releaseInvoker.runMavenBuild(reactor);
+	}
+
+	@Test
+	public void runMavenBuild_InvocationFailed() throws Exception {
+		final MavenInvocationException expected = new MavenInvocationException("anyMessage");
+		doThrow(expected).when(invoker).execute(request);
+		try {
+			releaseInvoker.runMavenBuild(reactor);
+			fail("Exception expected here");
+		} catch (final MojoExecutionException e) {
+			assertSame(expected, e.getCause());
+		}
+	}
+}


### PR DESCRIPTION
Hi again,

I added support for specifying custom global/user Maven settings for the release build invocation. This is necessary to make the plugin work in a Cloudbees Jenkins instance. More or less the same reason as for my last pull-request related to SSH private keys / known_hosts.

Have a nice day