### PR TITLE
Feature/detect snapshot in version property

### DIFF
--- a/src/test/java/e2e/ValidationTest.java
+++ b/src/test/java/e2e/ValidationTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static scaffolding.ExactCountMatcher.oneOf;
 import static scaffolding.ExactCountMatcher.twoOf;
+import static scaffolding.ExactCountMatcher.fourOf;
 import static scaffolding.GitMatchers.hasCleanWorkingDirectory;
 
 import java.io.File;
@@ -144,7 +145,7 @@ public class ValidationTest {
             badOne.mvnRelease("1");
             Assert.fail("Should not have worked as there are snapshot dependencies");
         } catch (MavenExecutionException mee) {
-            assertThat(mee.output, twoOf(containsString("Cannot release with references to snapshot dependencies")));
+            assertThat(mee.output, fourOf(containsString("Cannot release with references to snapshot dependencies")));
             assertThat(mee.output, oneOf(containsString("The following dependency errors were found:")));
             assertThat(mee.output, oneOf(containsString(" * snapshot-dependencies-with-version-properties references dependency core-utils 2.0-SNAPSHOT")));
         }

--- a/src/test/java/e2e/ValidationTest.java
+++ b/src/test/java/e2e/ValidationTest.java
@@ -146,7 +146,7 @@ public class ValidationTest {
         } catch (MavenExecutionException mee) {
             assertThat(mee.output, twoOf(containsString("Cannot release with references to snapshot dependencies")));
             assertThat(mee.output, oneOf(containsString("The following dependency errors were found:")));
-            assertThat(mee.output, oneOf(containsString(" * snapshot-dependencies-with-version-properties references dependency core-utils 2.0-SNAPSHOT")));
+            assertThat(mee.output, oneOf(containsString(" * snapshot-dependencies-with-version-properties references dependency core-utils ${core-utils.version}")));
         }
 
         assertThat(badOne.local, hasCleanWorkingDirectory());

--- a/src/test/java/e2e/ValidationTest.java
+++ b/src/test/java/e2e/ValidationTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static scaffolding.ExactCountMatcher.oneOf;
 import static scaffolding.ExactCountMatcher.twoOf;
-import static scaffolding.ExactCountMatcher.fourOf;
 import static scaffolding.GitMatchers.hasCleanWorkingDirectory;
 
 import java.io.File;
@@ -145,7 +144,7 @@ public class ValidationTest {
             badOne.mvnRelease("1");
             Assert.fail("Should not have worked as there are snapshot dependencies");
         } catch (MavenExecutionException mee) {
-            assertThat(mee.output, fourOf(containsString("Cannot release with references to snapshot dependencies")));
+            assertThat(mee.output, twoOf(containsString("Cannot release with references to snapshot dependencies")));
             assertThat(mee.output, oneOf(containsString("The following dependency errors were found:")));
             assertThat(mee.output, oneOf(containsString(" * snapshot-dependencies-with-version-properties references dependency core-utils 2.0-SNAPSHOT")));
         }

--- a/src/test/java/e2e/ValidationTest.java
+++ b/src/test/java/e2e/ValidationTest.java
@@ -1,26 +1,24 @@
 package e2e;
 
-import com.github.danielflower.mavenplugins.release.FileUtils;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static scaffolding.ExactCountMatcher.oneOf;
+import static scaffolding.ExactCountMatcher.twoOf;
+import static scaffolding.ExactCountMatcher.fourOf;
+import static scaffolding.GitMatchers.hasCleanWorkingDirectory;
+
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import scaffolding.GitMatchers;
+
 import scaffolding.MavenExecutionException;
 import scaffolding.MvnRunner;
 import scaffolding.TestProject;
-
-import java.io.File;
-import java.io.IOException;
-
-import static com.github.danielflower.mavenplugins.release.FileUtils.pathOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static scaffolding.ExactCountMatcher.noneOf;
-import static scaffolding.ExactCountMatcher.oneOf;
-import static scaffolding.ExactCountMatcher.twoOf;
-import static scaffolding.GitMatchers.hasCleanWorkingDirectory;
 
 public class ValidationTest {
 
@@ -133,4 +131,25 @@ public class ValidationTest {
         assertThat(badOne.local, hasCleanWorkingDirectory());
     }
 
+    @Test
+    public void failsIfThereAreDependenciesOnSnapshotVersionsWithVersionPropertiesThatAreNotPartOfTheReactor() throws Exception {
+        // Install the snapshot dependency so that it can be built
+        TestProject dependency = TestProject.independentVersionsProject();
+        dependency.mvn("install");
+    	
+        TestProject badOne = TestProject.moduleWithSnapshotDependenciesWithVersionProperties();
+
+        badOne.mvn("install"); // this should work as the snapshot dependency is in the local repo
+
+        try {
+            badOne.mvnRelease("1");
+            Assert.fail("Should not have worked as there are snapshot dependencies");
+        } catch (MavenExecutionException mee) {
+            assertThat(mee.output, fourOf(containsString("Cannot release with references to snapshot dependencies")));
+            assertThat(mee.output, oneOf(containsString("The following dependency errors were found:")));
+            assertThat(mee.output, oneOf(containsString(" * snapshot-dependencies-with-version-properties references dependency core-utils 2.0-SNAPSHOT")));
+        }
+
+        assertThat(badOne.local, hasCleanWorkingDirectory());
+    }
 }

--- a/src/test/java/scaffolding/ExactCountMatcher.java
+++ b/src/test/java/scaffolding/ExactCountMatcher.java
@@ -58,4 +58,9 @@ public class ExactCountMatcher extends TypeSafeDiagnosingMatcher<List<String>> {
     public static Matcher<? super List<String>> threeOf(Matcher<String> stringMatcher) {
         return new ExactCountMatcher(stringMatcher, 3);
     }
+    
+    @Factory
+    public static Matcher<? super List<String>> fourOf(Matcher<String> stringMatcher) {
+        return new ExactCountMatcher(stringMatcher, 4);
+    }
 }

--- a/src/test/java/scaffolding/TestProject.java
+++ b/src/test/java/scaffolding/TestProject.java
@@ -160,6 +160,9 @@ public class TestProject {
     public static TestProject moduleWithSnapshotDependencies() {
         return project("snapshot-dependencies");
     }
+    public static TestProject moduleWithSnapshotDependenciesWithVersionProperties() {
+        return project("snapshot-dependencies-with-version-properties");
+    }
 
     public void setMvnRunner(MvnRunner mvnRunner) {
         this.mvnRunner = mvnRunner;

--- a/test-projects/snapshot-dependencies-with-version-properties/.gitignore
+++ b/test-projects/snapshot-dependencies-with-version-properties/.gitignore
@@ -1,0 +1,6 @@
+target
+.idea/
+*.iml
+.classpath
+.settings
+.project

--- a/test-projects/snapshot-dependencies-with-version-properties/assembly-descriptor.xml
+++ b/test-projects/snapshot-dependencies-with-version-properties/assembly-descriptor.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <!-- TODO: a jarjar format would be better -->
+    <id>package</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/test-projects/snapshot-dependencies-with-version-properties/pom.xml
+++ b/test-projects/snapshot-dependencies-with-version-properties/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.snapshotdependencies</groupId>
+    <artifactId>snapshot-dependencies-with-version-properties</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Project with snapshot dependencies</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        
+        <core-utils.version>2.0-SNAPSHOT</core-utils.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.danielflower.mavenplugins.testprojects.independentversions</groupId>
+            <artifactId>core-utils</artifactId>
+            <version>${core-utils.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.google.code.echo-maven-plugin</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <message>Hello from version ${project.version}!</message>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>echo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>assembly-descriptor.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/test-projects/snapshot-dependencies-with-version-properties/src/main/java/com/github/danielflower/mavenplugins/testproject/snapshotdependencies/Main.java
+++ b/test-projects/snapshot-dependencies-with-version-properties/src/main/java/com/github/danielflower/mavenplugins/testproject/snapshotdependencies/Main.java
@@ -1,0 +1,7 @@
+package com.github.danielflower.mavenplugins.testproject.snapshotdependencies;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world");
+    }
+}


### PR DESCRIPTION
Hi,

this pull request handles the following scenario:
A maven project has non module dependencies with versions set by properties. If such a property contains a SNAPSHOT version, this is not properly detected by release plugin and a release is created that contains SNAPSHOT dependencies.

With this pull request the problem is handled properly, i.e. release plugin will report that it cannot create a release as there are still SNAPSHOT dependencies in the project.

Corresponding test and test project snapshot-dependencies-with-version-properties is added.