### PR TITLE
support dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>2.2.1</version>
+            <version>3.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -178,6 +178,12 @@
     		<version>2.0.2-beta</version>
     		<scope>test</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>backport-util-concurrent</groupId>
+            <artifactId>backport-util-concurrent</artifactId>
+            <version>3.1</version>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/com/github/danielflower/mavenplugins/release/MavenVersionResolver.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/MavenVersionResolver.java
@@ -1,0 +1,38 @@
+package com.github.danielflower.mavenplugins.release;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+
+public class MavenVersionResolver {
+
+    public static void resolveVersionsDefinedThroughProperties(List<MavenProject> projects) {
+        for (MavenProject project : projects) {
+            if (isVersionDefinedWithProperty(project.getVersion())) {
+                project.setVersion(resolveVersion(project.getVersion(), project.getProperties()));
+            }
+        }
+
+    }
+
+    public static String resolveVersion(String version, Properties projectProperties) {
+        if (isVersionDefinedWithProperty(version)) {
+            return projectProperties.getProperty(version.replace("${", "").replace("}", ""), version);
+        }
+        return version;
+    }
+
+    private static boolean isVersionDefinedWithProperty(String version) {
+        return version != null && version.startsWith("${");
+    }
+
+    public static boolean isMultiModuleReleasePlugin(Plugin plugin) {
+        return plugin.getGroupId().equals("com.github.danielflower.mavenplugins") && plugin.getArtifactId().equals("multi-module-maven-release-plugin");
+    }
+
+    public static boolean isSnapshot(String version) {
+        return (version != null && version.endsWith("-SNAPSHOT"));
+    }
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/release/PomUpdater.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/PomUpdater.java
@@ -1,17 +1,17 @@
 package com.github.danielflower.mavenplugins.release;
 
+import java.io.File;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.List;
 import org.codehaus.plexus.util.WriterFactory;
 
 public class PomUpdater {
@@ -78,7 +78,7 @@ public class PomUpdater {
 
         String searchingFrom = project.getArtifactId();
         MavenProject parent = project.getParent();
-        if (parent != null && isSnapshot(parent.getVersion())) {
+        if (parent != null && MavenVersionResolver.isSnapshot(parent.getVersion())) {
             try {
                 ReleasableModule parentBeingReleased = reactor.find(parent.getGroupId(), parent.getArtifactId(), parent.getVersion());
                 originalModel.getParent().setVersion(parentBeingReleased.getVersionToDependOn());
@@ -87,9 +87,11 @@ public class PomUpdater {
                 errors.add("The parent of " + searchingFrom + " is " + e.artifactId + " " + e.version);
             }
         }
+
+        Properties projectProperties = project.getProperties();
         for (Dependency dependency : originalModel.getDependencies()) {
             String version = dependency.getVersion();
-            if (isSnapshot(version)) {
+            if (MavenVersionResolver.isSnapshot(MavenVersionResolver.resolveVersion(version, projectProperties))) {
                 try {
                     ReleasableModule dependencyBeingReleased = reactor.find(dependency.getGroupId(), dependency.getArtifactId(), version);
                     dependency.setVersion(dependencyBeingReleased.getVersionToDependOn());
@@ -100,9 +102,28 @@ public class PomUpdater {
             }else
                 log.debug(" Dependency on " + dependency.getArtifactId() + " kept at version " + dependency.getVersion());
         }
+        //Support for dependency management
+        if (originalModel.getDependencyManagement() != null) {
+            for (Dependency dependency : originalModel.getDependencyManagement().getDependencies()) {
+                String version = dependency.getVersion();
+                if (MavenVersionResolver.isSnapshot(MavenVersionResolver.resolveVersion(version, projectProperties))) {
+                    try {
+                        ReleasableModule dependencyBeingReleased = reactor.find(dependency.getGroupId(), dependency.getArtifactId(), version);
+                        dependency.setVersion(dependencyBeingReleased.getVersionToDependOn());
+                        log.debug(" Dependency on " + dependencyBeingReleased.getArtifactId() + " rewritten to version " + dependencyBeingReleased.getVersionToDependOn());
+                    } catch (UnresolvedSnapshotDependencyException e) {
+                        errors.add(searchingFrom + " references dependency " + e.artifactId + " " + e.version);
+                    }
+                }
+                else {
+                    log.debug(" Dependency on " + dependency.getArtifactId() + " kept at version " + dependency.getVersion());
+                }
+            }
+        }
+
         for (Plugin plugin : project.getModel().getBuild().getPlugins()) {
             String version = plugin.getVersion();
-            if (isSnapshot(version)) {
+            if (MavenVersionResolver.isSnapshot(MavenVersionResolver.resolveVersion(version, projectProperties))) {
                 if (!isMultiModuleReleasePlugin(plugin)) {
                     errors.add(searchingFrom + " references plugin " + plugin.getArtifactId() + " " + version);
                 }
@@ -110,13 +131,12 @@ public class PomUpdater {
         }
         return errors;
     }
+    
+
 
     private static boolean isMultiModuleReleasePlugin(Plugin plugin) {
         return plugin.getGroupId().equals("com.github.danielflower.mavenplugins") && plugin.getArtifactId().equals("multi-module-maven-release-plugin");
     }
 
-    private boolean isSnapshot(String version) {
-        return (version != null && version.endsWith("-SNAPSHOT"));
-    }
 
 }

--- a/src/test/java/e2e/BomDependencyTest.java
+++ b/src/test/java/e2e/BomDependencyTest.java
@@ -1,0 +1,120 @@
+package e2e;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static scaffolding.ExactCountMatcher.oneOf;
+import static scaffolding.GitMatchers.hasTag;
+
+import java.util.List;
+
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import scaffolding.MvnRunner;
+import scaffolding.TestProject;
+
+public class BomDependencyTest {
+
+    final TestProject testProject = TestProject.dependencyManagementProject();
+
+    @BeforeClass
+    public static void installPluginToLocalRepo() throws MavenInvocationException {
+        MvnRunner.installReleasePluginToLocalRepo();
+    }
+
+    @Test
+    public void willReleaseAllWhenBomIsChanged() throws Exception {
+        testProject.mvnRelease("1");
+        testProject.commitRandomFile("root-bom").pushIt();
+        List<String> output = testProject.mvnRelease("2");
+
+        assertTagExists("root-bom-1.0.2");
+        assertTagExists("parent-module-1.2.3.2");
+        assertTagExists("core-utils-2.0.2");
+        assertTagExists("more-utils-10.0.2");
+        assertTagExists("console-app-3.2.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+        
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.2 for root-bom as it has changed since the last release.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing parent-module 1.2.3.2 as root-bom has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing more-utils 10.0.2 as root-bom has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing core-utils 2.0.2 as root-bom has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing console-app 3.2.2 as root-bom has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for dependencymanagement-aggregator as it has not been changed since that release.")));
+    }
+
+    @Test
+    public void willReleaseAllButBomWhenParentIsChanged() throws Exception {
+        testProject.mvnRelease("1");
+        testProject.commitRandomFile("parent-module").pushIt();
+        List<String> output = testProject.mvnRelease("2");
+
+        assertTagDoesNotExist("root-bom-1.0.2");
+        assertTagExists("parent-module-1.2.3.2");
+        assertTagExists("core-utils-2.0.2");
+        assertTagExists("more-utils-10.0.2");
+        assertTagExists("console-app-3.2.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+        
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for root-bom as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.2 for parent-module as it has changed since the last release.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing more-utils 10.0.2 as parent-module has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing core-utils 2.0.2 as parent-module has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing console-app 3.2.2 as parent-module has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for dependencymanagement-aggregator as it has not been changed since that release.")));
+    }
+
+    @Test
+    public void willReleaseConsoleAppAndCoreUtilsWhenCoreUtilsIsChanged() throws Exception {
+        testProject.mvnRelease("1");
+        testProject.commitRandomFile("the-core-utilities").pushIt();
+        List<String> output = testProject.mvnRelease("2");
+
+        assertTagDoesNotExist("root-bom-1.0.2");
+        assertTagDoesNotExist("parent-module-1.2.3.2");
+        assertTagExists("core-utils-2.0.2");
+        assertTagDoesNotExist("more-utils-10.0.2");
+        assertTagExists("console-app-3.2.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+        
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for root-bom as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for parent-module as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 10.0.1 for more-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 2.0.2 for core-utils as it has changed since the last release.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing console-app 3.2.2 as core-utils has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for dependencymanagement-aggregator as it has not been changed since that release.")));
+    }
+    
+    @Test
+    public void willReleaseOnlyConsoleAppWhenConsoleAppIsChanged() throws Exception {
+        testProject.mvnRelease("1");
+        testProject.commitRandomFile("console-app").pushIt();
+        List<String> output = testProject.mvnRelease("2");
+
+        assertTagDoesNotExist("root-bom-1.0.2");
+        assertTagDoesNotExist("parent-module-1.2.3.2");
+        assertTagDoesNotExist("core-utils-2.0.2");
+        assertTagDoesNotExist("more-utils-10.0.2");
+        assertTagExists("console-app-3.2.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+        
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for root-bom as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for parent-module as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 10.0.1 for more-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 2.0.1 for core-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 3.2.2 for console-app as it has changed since the last release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for dependencymanagement-aggregator as it has not been changed since that release.")));
+    }
+
+    private void assertTagDoesNotExist(String tagName) {
+        assertThat(testProject.local, not(hasTag(tagName)));
+        assertThat(testProject.origin, not(hasTag(tagName)));
+    }
+
+    private void assertTagExists(String tagName) {
+        assertThat(testProject.local, hasTag(tagName));
+        assertThat(testProject.origin, hasTag(tagName));
+    }
+}

--- a/src/test/java/e2e/BomDependencyUsingParentModuleVersionTest.java
+++ b/src/test/java/e2e/BomDependencyUsingParentModuleVersionTest.java
@@ -1,0 +1,132 @@
+package e2e;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static scaffolding.ExactCountMatcher.oneOf;
+import static scaffolding.GitMatchers.hasTag;
+
+import java.util.List;
+
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import scaffolding.MvnRunner;
+import scaffolding.TestProject;
+
+public class BomDependencyUsingParentModuleVersionTest {
+
+    final TestProject testProject = TestProject.dependencyManagementUsingParentModuleVersionPropertyProject();
+
+    @BeforeClass
+    public static void installPluginToLocalRepo() throws MavenInvocationException {
+        MvnRunner.installReleasePluginToLocalRepo();
+    }
+
+    @Test
+    public void willReleaseAllWhenBomIsChanged() throws Exception {
+    	// needed to populate maven repository in case it is first ever build
+    	testProject.mvn("install");
+
+    	testProject.mvnRelease("1");
+        testProject.commitRandomFile("root-bom").pushIt();
+        List<String> output = testProject.mvnRelease("2");
+
+        assertTagExists("root-bom-1.0.2");
+        assertTagExists("parent-module-1.2.3.2");
+        assertTagExists("core-utils-1.2.3.2");
+        assertTagExists("more-utils-1.2.3.2");
+        assertTagExists("console-app-1.2.3.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+        
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.2 for root-bom as it has changed since the last release.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing parent-module 1.2.3.2 as root-bom has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing more-utils 1.2.3.2 as root-bom has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing core-utils 1.2.3.2 as root-bom has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing console-app 1.2.3.2 as root-bom has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for dependencymanagement-aggregator as it has not been changed since that release.")));
+    }    
+
+    @Test
+    public void willReleaseAllButBomWhenParentIsChanged() throws Exception {
+    	// needed to populate maven repository in case it is first ever build    	
+    	testProject.mvn("install");    	
+
+    	testProject.mvnRelease("1");
+        testProject.commitRandomFile("parent-module").pushIt();
+        List<String> output = testProject.mvnRelease("2");
+
+        assertTagDoesNotExist("root-bom-1.0.2");
+        assertTagExists("parent-module-1.2.3.2");
+        assertTagExists("core-utils-1.2.3.2");
+        assertTagExists("more-utils-1.2.3.2");
+        assertTagExists("console-app-1.2.3.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+        
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for root-bom as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.2 for parent-module as it has changed since the last release.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing more-utils 1.2.3.2 as parent-module has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing core-utils 1.2.3.2 as parent-module has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing console-app 1.2.3.2 as parent-module has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for dependencymanagement-aggregator as it has not been changed since that release.")));
+    }    
+    
+    @Test
+    public void willReleaseConsoleAppAndCoreUtilsWhenCoreUtilsIsChanged() throws Exception {
+    	// needed to populate maven repository in case it is first ever build    	
+    	testProject.mvn("install");
+
+    	testProject.mvnRelease("1");
+        testProject.commitRandomFile("the-core-utilities").pushIt();
+        List<String> output = testProject.mvnRelease("2");
+
+        assertTagDoesNotExist("root-bom-1.0.2");
+        assertTagDoesNotExist("parent-module-1.2.3.2");
+        assertTagExists("core-utils-1.2.3.2");
+        assertTagDoesNotExist("more-utils-1.2.3.2");
+        assertTagExists("console-app-1.2.3.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+        
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for root-bom as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for parent-module as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for more-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.2 for core-utils as it has changed since the last release.")));
+        assertThat(output, oneOf(containsString("[INFO] Releasing console-app 1.2.3.2 as core-utils has changed.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for dependencymanagement-aggregator as it has not been changed since that release.")));
+    }    
+    
+    @Test
+    public void willReleaseOnlyConsoleAppWhenConsoleAppIsChanged() throws Exception {
+    	// needed to populate maven repository in case it is first ever build    	
+    	testProject.mvn("install");
+    	
+        testProject.mvnRelease("1");
+        testProject.commitRandomFile("console-app").pushIt();
+        List<String> output = testProject.mvnRelease("2");
+
+        assertTagDoesNotExist("root-bom-1.0.2");
+        assertTagDoesNotExist("parent-module-1.2.3.2");
+        assertTagDoesNotExist("core-utils-1.2.3.2");
+        assertTagDoesNotExist("more-utils-1.2.3.2");
+        assertTagExists("console-app-1.2.3.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+        
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for root-bom as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for parent-module as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for more-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for core-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.2 for console-app as it has changed since the last release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for dependencymanagement-aggregator as it has not been changed since that release.")));
+    }
+    
+    private void assertTagDoesNotExist(String tagName) {
+        assertThat(testProject.local, not(hasTag(tagName)));
+        assertThat(testProject.origin, not(hasTag(tagName)));
+    }
+
+    private void assertTagExists(String tagName) {
+        assertThat(testProject.local, hasTag(tagName));
+        assertThat(testProject.origin, hasTag(tagName));
+    }
+}

--- a/src/test/java/scaffolding/ExactCountMatcher.java
+++ b/src/test/java/scaffolding/ExactCountMatcher.java
@@ -58,4 +58,9 @@ public class ExactCountMatcher extends TypeSafeDiagnosingMatcher<List<String>> {
     public static Matcher<? super List<String>> threeOf(Matcher<String> stringMatcher) {
         return new ExactCountMatcher(stringMatcher, 3);
     }
+    
+    @Factory
+    public static Matcher<? super List<String>> fourOf(Matcher<String> stringMatcher) {
+        return new ExactCountMatcher(stringMatcher, 4);
+    }
 }

--- a/src/test/java/scaffolding/MvnRunner.java
+++ b/src/test/java/scaffolding/MvnRunner.java
@@ -1,5 +1,6 @@
 package scaffolding;
 
+import edu.emory.mathcs.backport.java.util.Arrays;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.maven.shared.invoker.*;
 
@@ -57,9 +58,20 @@ public class MvnRunner {
     }
 
     public List<String> runMaven(File workingDir, String... arguments) {
+        return runMavenInternal(workingDir, null, arguments);
+    }
+
+    public List<String> runMavenWithProfile(File workingDir, String profile, String...arguments) {
+        return runMavenInternal(workingDir, profile, arguments);
+    }
+
+    private List<String> runMavenInternal(File workingDir, String profile, String[] arguments) {
         InvocationRequest request = new DefaultInvocationRequest();
         request.setGoals(asList(arguments));
         request.setBaseDirectory(workingDir);
+        if (profile != null) {
+            request.setProfiles(Arrays.asList(new String[]{profile}));
+        }
 
         Invoker invoker = new DefaultInvoker();
 

--- a/src/test/java/scaffolding/TestProject.java
+++ b/src/test/java/scaffolding/TestProject.java
@@ -43,6 +43,10 @@ public class TestProject {
         return mvnRunner.runMaven(localDir, arguments);
     }
 
+    public List<String> mvnWithProfile(String profile, String... arguments) throws IOException {
+        return mvnRunner.runMavenWithProfile(localDir, profile, arguments);
+    }
+
     public List<String> mvnRelease(String buildNumber) throws IOException, InterruptedException {
         return mvnRunner.runMaven(localDir,
             "-DbuildNumber=" + buildNumber,
@@ -114,7 +118,7 @@ public class TestProject {
             xml = xml.replace("${current.plugin.version}", PLUGIN_VERSION_FOR_TESTS);
             FileUtils.writeStringToFile(pom, xml, "UTF-8");
         }
-        for (File child : sourceDir.listFiles((FileFilter)FileFilterUtils.directoryFileFilter())) {
+        for (File child : sourceDir.listFiles((FileFilter) FileFilterUtils.directoryFileFilter())) {
             performPomSubstitution(child);
         }
     }
@@ -150,15 +154,28 @@ public class TestProject {
     public static TestProject parentAsSibilngProject() {
         return project("parent-as-sibling");
     }
+
     public static TestProject deepDependenciesProject() {
         return project("deep-dependencies");
     }
 
+    public static TestProject dependencyManagementProject() {
+        return project("dependencymanagement");
+    }
+
+    public static TestProject dependencyManagementUsingParentModuleVersionPropertyProject() {
+	    return project("dependencymanagement-using-parent-module-version-property");
+    }
+    
     public static TestProject moduleWithTestFailure() {
         return project("module-with-test-failure");
     }
+
     public static TestProject moduleWithSnapshotDependencies() {
         return project("snapshot-dependencies");
+    }
+    public static TestProject moduleWithSnapshotDependenciesWithVersionProperties() {
+        return project("snapshot-dependencies-with-version-properties");
     }
 
     public void setMvnRunner(MvnRunner mvnRunner) {

--- a/test-projects/dependencymanagement-using-parent-module-version-property/.gitignore
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/.gitignore
@@ -1,0 +1,6 @@
+target
+.idea/
+*.iml
+.classpath
+.settings
+.project

--- a/test-projects/dependencymanagement-using-parent-module-version-property/README.md
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/README.md
@@ -1,0 +1,8 @@
+In this project the aggregator pom is separate from the parent pom of the modules in this project.
+
+Other modules reference the parent pom using a relative path, version is set by ${parent-module.version}.
+
+This is a malformed maven project, as parent version should not be set by a property.
+Build even reports a warning saying that such malformed project may not compile any more in future.
+
+But in a scenario with a huge multi module project being developed on many branches with different versions, this significantly simplifies merging, as there is not module version related merge conflicts in pom files. 

--- a/test-projects/dependencymanagement-using-parent-module-version-property/console-app/pom.xml
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/console-app/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <artifactId>parent-module</artifactId>
+        <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+        <version>${parent-module.version}</version>
+        <relativePath>../parent-module/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>console-app</artifactId>
+    <version>${parent-module.version}</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+            <artifactId>core-utils</artifactId>
+            <version>${parent-module.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-projects/dependencymanagement-using-parent-module-version-property/console-app/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/App.java
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/console-app/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/App.java
@@ -1,0 +1,8 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+public class App {
+    public static void main(String[] args) {
+        Calculator calculator = new Calculator();
+        System.out.println("1 + 2 = " + calculator.add(1, 2));
+    }
+}

--- a/test-projects/dependencymanagement-using-parent-module-version-property/more-utilities/pom.xml
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/more-utilities/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>parent-module</artifactId>
+        <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+        <version>${parent-module.version}</version>
+        <relativePath>../parent-module/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>more-utils</artifactId>
+    <version>${parent-module.version}</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-projects/dependencymanagement-using-parent-module-version-property/more-utilities/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/more-utilities/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
@@ -1,0 +1,9 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+public class Calculator {
+
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+}

--- a/test-projects/dependencymanagement-using-parent-module-version-property/more-utilities/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/more-utilities/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
@@ -1,0 +1,14 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CalculatorTest {
+
+    @Test
+    public void testAdd() throws Exception {
+        Assert.assertEquals(3, new Calculator().add(1, 2));
+        System.out.println("The Calculator Test has run"); // used in a test to assert this has run
+    }
+}

--- a/test-projects/dependencymanagement-using-parent-module-version-property/parent-module/pom.xml
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/parent-module/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+    <artifactId>parent-module</artifactId>
+    <version>${parent-module.version}</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <parent-module.version>1.2.3-SNAPSHOT</parent-module.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+                <artifactId>root-bom</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-projects/dependencymanagement-using-parent-module-version-property/pom.xml
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+    <artifactId>dependencymanagement-aggregator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <modules>
+        <module>root-bom</module>
+        <module>parent-module</module>
+        <module>more-utilities</module>
+        <module>the-core-utilities</module>
+        <module>console-app</module>
+    </modules>
+</project>

--- a/test-projects/dependencymanagement-using-parent-module-version-property/root-bom/pom.xml
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/root-bom/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+    <artifactId>root-bom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <junit.version>4.0</junit.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-projects/dependencymanagement-using-parent-module-version-property/the-core-utilities/pom.xml
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/the-core-utilities/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>parent-module</artifactId>
+        <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+        <version>${parent-module.version}</version>
+        <relativePath>../parent-module/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>core-utils</artifactId>
+    <name>The Core Utilities</name>
+    <version>${parent-module.version}</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.danielflower.mavenplugins.testprojects.dependencymanagement-using-parent-module-version-property</groupId>
+            <artifactId>more-utils</artifactId>
+            <version>${parent-module.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-projects/dependencymanagement-using-parent-module-version-property/the-core-utilities/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/the-core-utilities/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
@@ -1,0 +1,9 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+public class Calculator {
+
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+}

--- a/test-projects/dependencymanagement-using-parent-module-version-property/the-core-utilities/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
+++ b/test-projects/dependencymanagement-using-parent-module-version-property/the-core-utilities/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
@@ -1,0 +1,14 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CalculatorTest {
+
+    @Test
+    public void testAdd() throws Exception {
+        Assert.assertEquals(3, new Calculator().add(1, 2));
+        System.out.println("The Calculator Test has run"); // used in a test to assert this has run
+    }
+}

--- a/test-projects/dependencymanagement/.gitignore
+++ b/test-projects/dependencymanagement/.gitignore
@@ -1,0 +1,6 @@
+target
+.idea/
+*.iml
+.classpath
+.settings
+.project

--- a/test-projects/dependencymanagement/README.md
+++ b/test-projects/dependencymanagement/README.md
@@ -1,0 +1,3 @@
+In this project the aggregator pom is separate from the parent pom of the modules in this project.
+
+Other modules reference the parent pom using a relative path.

--- a/test-projects/dependencymanagement/console-app/pom.xml
+++ b/test-projects/dependencymanagement/console-app/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>parent-module</artifactId>
+        <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+        <version>1.2.3-SNAPSHOT</version>
+        <relativePath>../parent-module/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>console-app</artifactId>
+    <version>3.2-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+            <artifactId>core-utils</artifactId>
+            <version>2.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-projects/dependencymanagement/console-app/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/App.java
+++ b/test-projects/dependencymanagement/console-app/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/App.java
@@ -1,0 +1,8 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+public class App {
+    public static void main(String[] args) {
+        Calculator calculator = new Calculator();
+        System.out.println("1 + 2 = " + calculator.add(1, 2));
+    }
+}

--- a/test-projects/dependencymanagement/more-utilities/pom.xml
+++ b/test-projects/dependencymanagement/more-utilities/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>parent-module</artifactId>
+        <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+        <version>1.2.3-SNAPSHOT</version>
+        <relativePath>../parent-module/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>more-utils</artifactId>
+    <version>10.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-projects/dependencymanagement/more-utilities/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
+++ b/test-projects/dependencymanagement/more-utilities/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
@@ -1,0 +1,9 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+public class Calculator {
+
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+}

--- a/test-projects/dependencymanagement/more-utilities/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
+++ b/test-projects/dependencymanagement/more-utilities/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
@@ -1,0 +1,14 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CalculatorTest {
+
+    @Test
+    public void testAdd() throws Exception {
+        Assert.assertEquals(3, new Calculator().add(1, 2));
+        System.out.println("The Calculator Test has run"); // used in a test to assert this has run
+    }
+}

--- a/test-projects/dependencymanagement/parent-module/pom.xml
+++ b/test-projects/dependencymanagement/parent-module/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+    <artifactId>parent-module</artifactId>
+    <version>1.2.3-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+                <artifactId>root-bom</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-projects/dependencymanagement/pom.xml
+++ b/test-projects/dependencymanagement/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+    <artifactId>dependencymanagement-aggregator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <modules>
+        <module>root-bom</module>
+        <module>the-core-utilities</module>
+        <module>console-app</module>
+        <module>parent-module</module>
+        <module>more-utilities</module>
+    </modules>
+</project>

--- a/test-projects/dependencymanagement/root-bom/pom.xml
+++ b/test-projects/dependencymanagement/root-bom/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+    <artifactId>root-bom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <junit.version>4.0</junit.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-projects/dependencymanagement/the-core-utilities/pom.xml
+++ b/test-projects/dependencymanagement/the-core-utilities/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>parent-module</artifactId>
+        <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+        <version>1.2.3-SNAPSHOT</version>
+        <relativePath>../parent-module/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>core-utils</artifactId>
+    <name>The Core Utilities</name>
+    <version>2.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.danielflower.mavenplugins.testprojects.dependecymanagement</groupId>
+            <artifactId>more-utils</artifactId>
+            <version>10.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-projects/dependencymanagement/the-core-utilities/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
+++ b/test-projects/dependencymanagement/the-core-utilities/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
@@ -1,0 +1,9 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+public class Calculator {
+
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+}

--- a/test-projects/dependencymanagement/the-core-utilities/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
+++ b/test-projects/dependencymanagement/the-core-utilities/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
@@ -1,0 +1,14 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CalculatorTest {
+
+    @Test
+    public void testAdd() throws Exception {
+        Assert.assertEquals(3, new Calculator().add(1, 2));
+        System.out.println("The Calculator Test has run"); // used in a test to assert this has run
+    }
+}

--- a/test-projects/snapshot-dependencies-with-version-properties/.gitignore
+++ b/test-projects/snapshot-dependencies-with-version-properties/.gitignore
@@ -1,0 +1,6 @@
+target
+.idea/
+*.iml
+.classpath
+.settings
+.project

--- a/test-projects/snapshot-dependencies-with-version-properties/assembly-descriptor.xml
+++ b/test-projects/snapshot-dependencies-with-version-properties/assembly-descriptor.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <!-- TODO: a jarjar format would be better -->
+    <id>package</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/test-projects/snapshot-dependencies-with-version-properties/pom.xml
+++ b/test-projects/snapshot-dependencies-with-version-properties/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.snapshotdependencies</groupId>
+    <artifactId>snapshot-dependencies-with-version-properties</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Project with snapshot dependencies</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        
+        <core-utils.version>2.0-SNAPSHOT</core-utils.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.danielflower.mavenplugins.testprojects.independentversions</groupId>
+            <artifactId>core-utils</artifactId>
+            <version>${core-utils.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.google.code.echo-maven-plugin</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <message>Hello from version ${project.version}!</message>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>echo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>assembly-descriptor.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/test-projects/snapshot-dependencies-with-version-properties/src/main/java/com/github/danielflower/mavenplugins/testproject/snapshotdependencies/Main.java
+++ b/test-projects/snapshot-dependencies-with-version-properties/src/main/java/com/github/danielflower/mavenplugins/testproject/snapshotdependencies/Main.java
@@ -1,0 +1,7 @@
+package com.github.danielflower.mavenplugins.testproject.snapshotdependencies;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world");
+    }
+}


### PR DESCRIPTION
Hi,

this pull requests supports the following scenario:
Given a multi-module project with bom module, that is managing version of third party (i.e. non module) dependencies. Other modules import bom as dependency management. If only bom module is changed, e.g. by updating version of a third party dependency, release plugin currently only releases bom module instead of all modules that import bom module.

With this pull request, bom module and any depending modules are released properly.

Tests and test projects dependencymanagement and dependencymanagement-using-parent-module-version-property added.
