### PR TITLE
Adding ability to control behavior when no modules have changed

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/release/BaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/BaseMojo.java
@@ -60,6 +60,13 @@ public abstract class BaseMojo extends AbstractMojo {
 	@Parameter(alias = "forceRelease", property = "forceRelease")
 	protected List<String> modulesToForceRelease;
 
+    /**
+     * Determines the action to take when no module changes are detected. Possible values:
+     * {@code ReleaseAll}, {@code ReleaseNone}, {@code FailBuild}
+     */
+    @Parameter(alias = "noChangesAction", defaultValue="ReleaseAll", property = "noChangesAction")
+    protected NoChangesAction noChangesAction;
+
 	@Parameter(property = "disableSshAgent")
 	private boolean disableSshAgent;
 

--- a/src/main/java/com/github/danielflower/mavenplugins/release/NextMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/NextMojo.java
@@ -33,7 +33,10 @@ public class NextMojo extends BaseMojo {
             configureJsch(log);
 
             LocalGitRepo repo = LocalGitRepo.fromCurrentDir(ReleaseMojo.getRemoteUrlOrNullIfNoneSet(project.getOriginalModel().getScm(), project.getModel().getScm()));
-            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease);
+            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction);
+            if (reactor == null) {
+                return;
+            }
             ReleaseMojo.figureOutTagNamesAndThrowIfAlreadyExists(reactor.getModulesInBuildOrder(), repo, modulesToRelease);
 
         } catch (ValidationException e) {

--- a/src/main/java/com/github/danielflower/mavenplugins/release/NoChangesAction.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/NoChangesAction.java
@@ -1,0 +1,5 @@
+package com.github.danielflower.mavenplugins.release;
+
+public enum NoChangesAction {
+    ReleaseAll, ReleaseNone, FailBuild;
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
@@ -110,7 +110,10 @@ public class ReleaseMojo extends BaseMojo {
             LocalGitRepo repo = LocalGitRepo.fromCurrentDir(getRemoteUrlOrNullIfNoneSet(project.getOriginalModel().getScm(), project.getModel().getScm()));
             repo.errorIfNotClean();
 
-            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease);
+            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction);
+            if (reactor == null) {
+                return;
+            }
 
             List<AnnotatedTag> proposedTags = figureOutTagNamesAndThrowIfAlreadyExists(reactor.getModulesInBuildOrder(), repo, modulesToRelease);
 

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+### 2.1.1
+
+* Adding ability to control the behavior when no changes are detected. New property noChangesAction can be set
+ to one of ReleaseAll, ReleaseNone, FailBuild; default is ReleaseAll.
+
 ### 2.1.0
 
 * When custom user settings or global settings are passed in to the command line (via `-s` or `-gs` arguments)

--- a/src/test/java/e2e/NextMojoTest.java
+++ b/src/test/java/e2e/NextMojoTest.java
@@ -73,6 +73,27 @@ public class NextMojoTest {
     }
 
     @Test
+    public void ifThereHaveBeenNoChangesCanOptToReleaseNoModules() throws Exception {
+        List<String> firstBuildOutput = testProject.mvnRelease("1");
+        assertThat(firstBuildOutput, noneOf(containsString("No changes have been detected in any modules so will re-release them all")));
+        assertThat(firstBuildOutput, noneOf(containsString("No changes have been detected in any modules so will not perform release")));
+        List<String> output = testProject.mvnReleaserNext("2", "-DnoChangesAction=ReleaseNone");
+
+        assertTagDoesNotExist("console-app-3.2.2");
+        assertTagDoesNotExist("parent-module-1.2.3.2");
+        assertTagDoesNotExist("core-utils-2.0.2");
+        assertTagDoesNotExist("more-utils-10.0.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for parent-module as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 10.0.1 for more-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 2.0.1 for core-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 3.2.1 for console-app as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for deep-dependencies-aggregator as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[WARNING] No changes have been detected in any modules so will not perform release")));
+    }
+
+    @Test
     public void ifADependencyHasNotChangedButSomethingItDependsOnHasChangedThenTheDependencyIsReReleased() throws Exception {
         testProject.mvnRelease("1");
         testProject.commitRandomFile("more-utilities").pushIt();

--- a/src/test/java/e2e/PartialReleaseTest.java
+++ b/src/test/java/e2e/PartialReleaseTest.java
@@ -36,7 +36,7 @@ public class PartialReleaseTest {
 
     @Test
     public void buildsAndInstallsAndTagsAllModules() throws Exception {
-        List<String> commandOutput = testProject.mvnRelease(buildNumber, "core-utils");
+        List<String> commandOutput = testProject.mvnRelease(buildNumber, "-DmodulesToRelease=core-utils");
         buildsEachProjectOnceAndOnlyOnce(commandOutput);
         installsAllModulesIntoTheRepoWithTheBuildNumber();
         theLocalAndRemoteGitReposAreTaggedWithTheModuleNameAndVersion();
@@ -44,8 +44,8 @@ public class PartialReleaseTest {
 
     @Test
     public void whenNoChangesHaveBeenDetectedTheRequestedModuleIsBuiltAnyway() throws IOException, InterruptedException {
-        testProject.mvnRelease("1", "core-utils");
-        testProject.mvnRelease(buildNumber, "core-utils");
+        testProject.mvnRelease("1", "-DmodulesToRelease=core-utils");
+        testProject.mvnRelease(buildNumber, "-DmodulesToRelease=core-utils");
     }
 
     private void buildsEachProjectOnceAndOnlyOnce(List<String> commandOutput) throws Exception {

--- a/src/test/java/e2e/SkippingUnchangedModulesTest.java
+++ b/src/test/java/e2e/SkippingUnchangedModulesTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 import static scaffolding.ExactCountMatcher.noneOf;
 import static scaffolding.ExactCountMatcher.oneOf;
 import static scaffolding.GitMatchers.hasTag;
@@ -73,6 +74,32 @@ public class SkippingUnchangedModulesTest {
         assertTagExists("core-utils-2.0.2");
         assertTagExists("more-utils-10.0.2");
         assertTagExists("deep-dependencies-aggregator-1.0.2");
+    }
+
+    @Test
+    public void ifThereHaveBeenNoChangesThenCanOptNotToReleaseAnything() throws Exception {
+        List<String> firstBuildOutput = testProject.mvnRelease("1");
+        assertThat(firstBuildOutput, noneOf(containsString("No changes have been detected in any modules so will not perform release")));
+        List<String> secondBuildOutput = testProject.mvnRelease("2", "-DnoChangesAction=ReleaseNone");
+        assertThat(secondBuildOutput, oneOf(containsString("No changes have been detected in any modules so will not perform release")));
+
+        assertTagExists("console-app-3.2.1");
+        assertTagExists("parent-module-1.2.3.1");
+        assertTagExists("core-utils-2.0.1");
+        assertTagExists("more-utils-10.0.1");
+        assertTagExists("deep-dependencies-aggregator-1.0.1");
+    }
+
+    @Test
+    public void ifThereHaveBeenNoChangesThenCanOptToFailTheBuild() throws Exception {
+        List<String> firstBuildOutput = testProject.mvnRelease("1");
+        assertThat(firstBuildOutput, noneOf(containsString("No changes have been detected in any modules so will not perform release")));
+        try {
+            testProject.mvnRelease("2", "-DnoChangesAction=FailBuild");
+            fail("Expected an exception to be thrown");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("No module changes have been detected"));
+        }
     }
 
     @Test

--- a/src/test/java/scaffolding/TestProject.java
+++ b/src/test/java/scaffolding/TestProject.java
@@ -43,23 +43,12 @@ public class TestProject {
         return mvnRunner.runMaven(localDir, arguments);
     }
 
-    public List<String> mvnRelease(String buildNumber) throws IOException, InterruptedException {
-        return mvnRunner.runMaven(localDir,
-            "-DbuildNumber=" + buildNumber,
-            "releaser:release");
+    public List<String> mvnRelease(String buildNumber, String...arguments) throws IOException, InterruptedException {
+        return mvnRun("releaser:release", buildNumber, arguments);
     }
 
-    public List<String> mvnReleaserNext(String buildNumber) throws IOException, InterruptedException {
-        return mvnRunner.runMaven(localDir,
-            "-DbuildNumber=" + buildNumber,
-            "releaser:next");
-    }
-
-    public List<String> mvnRelease(String buildNumber, String moduleToRelease) throws IOException, InterruptedException {
-        return mvnRunner.runMaven(localDir,
-            "-DbuildNumber=" + buildNumber,
-            "-DmodulesToRelease=" + moduleToRelease,
-            "releaser:release");
+    public List<String> mvnReleaserNext(String buildNumber, String...arguments) throws IOException, InterruptedException {
+        return mvnRun("releaser:next", buildNumber, arguments);
     }
 
     public TestProject commitRandomFile(String module) throws IOException, GitAPIException {
@@ -77,6 +66,14 @@ public class TestProject {
 
     public void pushIt() throws GitAPIException {
         local.push().call();
+    }
+
+    private List<String> mvnRun(String goal, String buildNumber, String[] arguments) {
+        String[] args = new String[arguments.length + 2];
+        args[0] = "-DbuildNumber=" + buildNumber;
+        System.arraycopy(arguments, 0, args, 1, arguments.length);
+        args[args.length-1] = goal;
+        return mvnRunner.runMaven(localDir, args);
     }
 
     private static TestProject project(String name) {


### PR DESCRIPTION
Can now specify a "noChangesAction" with possible values: ReleaseAll, ReleaseNone, FailBuild

Default is ReleaseAll to preserve the current behavior.

Fixes #4