### PR TITLE
Force a release of a module when no change is detected but the respective artifact cannot be resolved.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-settings-builder</artifactId>
             <version>3.3.9</version>
         </dependency>

--- a/src/main/java/com/github/danielflower/mavenplugins/release/BaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/BaseMojo.java
@@ -1,8 +1,12 @@
 package com.github.danielflower.mavenplugins.release;
 
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Server;
@@ -66,6 +70,31 @@ public abstract class BaseMojo extends AbstractMojo {
      */
     @Parameter(alias = "noChangesAction", defaultValue="ReleaseAll", property = "noChangesAction")
     protected NoChangesAction noChangesAction;
+
+    /**
+     * Used to look up Artifacts in the remote repository.
+     */
+    @Component
+    protected ArtifactFactory factory;
+
+    /**
+     * Used to look up Artifacts in the remote repository.
+     */
+    @Component
+    protected ArtifactResolver artifactResolver;
+
+    /**
+     * List of Remote Repositories used by the resolver
+     */
+    @Parameter(property = "remoteRepositories", required = true, readonly = true, defaultValue = "${project.remoteArtifactRepositories}")
+    protected List remoteRepositories;
+
+    /**
+     * Location of the local repository.
+     *
+     */
+    @Parameter(property = "localRepository", required = true, readonly = true, defaultValue = "${localRepository}")
+    protected ArtifactRepository localRepository;
 
 	@Parameter(property = "disableSshAgent")
 	private boolean disableSshAgent;

--- a/src/main/java/com/github/danielflower/mavenplugins/release/NextMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/NextMojo.java
@@ -33,7 +33,8 @@ public class NextMojo extends BaseMojo {
             configureJsch(log);
 
             LocalGitRepo repo = LocalGitRepo.fromCurrentDir(ReleaseMojo.getRemoteUrlOrNullIfNoneSet(project.getOriginalModel().getScm(), project.getModel().getScm()));
-            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction);
+            ResolverWrapper resolverWrapper = new ResolverWrapper(factory, artifactResolver, remoteRepositories, localRepository);
+            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction, resolverWrapper);
             if (reactor == null) {
                 return;
             }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
@@ -110,7 +110,8 @@ public class ReleaseMojo extends BaseMojo {
             LocalGitRepo repo = LocalGitRepo.fromCurrentDir(getRemoteUrlOrNullIfNoneSet(project.getOriginalModel().getScm(), project.getModel().getScm()));
             repo.errorIfNotClean();
 
-            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction);
+            ResolverWrapper resolverWrapper = new ResolverWrapper(factory, artifactResolver, remoteRepositories, localRepository);
+            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction, resolverWrapper);
             if (reactor == null) {
                 return;
             }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ResolverWrapper.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ResolverWrapper.java
@@ -1,0 +1,63 @@
+package com.github.danielflower.mavenplugins.release;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
+import org.apache.maven.artifact.resolver.ArtifactResolutionException;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.plugin.logging.Log;
+
+import java.util.List;
+
+/**
+ *
+ */
+public class ResolverWrapper {
+
+    private final ArtifactFactory factory;
+
+    private final ArtifactResolver artifactResolver;
+
+    private final List remoteRepositories;
+
+    private final ArtifactRepository localRepository;
+
+    public ResolverWrapper(ArtifactFactory factory, ArtifactResolver artifactResolver, List remoteRepositories, ArtifactRepository localRepository) {
+        this.factory = factory;
+        this.artifactResolver = artifactResolver;
+        this.remoteRepositories = remoteRepositories;
+        this.localRepository = localRepository;
+    }
+
+    public ArtifactFactory getFactory() {
+        return factory;
+    }
+
+    public ArtifactResolver getArtifactResolver() {
+        return artifactResolver;
+    }
+
+    public List getRemoteRepositories() {
+        return remoteRepositories;
+    }
+
+    public ArtifactRepository getLocalRepository() {
+        return localRepository;
+    }
+
+    public boolean isResolvable(String groupId, String artifactId, String version, String type, Log log) {
+        try {
+            Artifact pomArtifact = this.factory.createArtifact(groupId, artifactId, version, "", type);
+            artifactResolver.resolve(pomArtifact, remoteRepositories, localRepository);
+            return true;
+
+        } catch (ArtifactResolutionException e) {
+            log.warn("can't resolve parent pom: " + e.getMessage());
+        } catch (ArtifactNotFoundException e) {
+            log.info("can't resolve artifact: " + e.getMessage());
+        }
+
+        return false;
+    }
+}

--- a/src/test/java/e2e/SkippingUnchangedModulesTest.java
+++ b/src/test/java/e2e/SkippingUnchangedModulesTest.java
@@ -91,6 +91,29 @@ public class SkippingUnchangedModulesTest {
     }
 
     @Test
+    public void ifThereHaveBeenNoChangesButArtifactsCannotBeResolvedThenReleaseIsForcedForTheseArtifacts() throws Exception {
+        List<String> firstBuildOutput = testProject.mvnRelease("1", "-DnoChangesAction=ReleaseNone");
+        assertThat(firstBuildOutput, noneOf(containsString("No changes have been detected in any modules so will not perform release")));
+
+        assertTagExists("console-app-3.2.1");
+        assertTagExists("parent-module-1.2.3.1");
+        assertTagExists("core-utils-2.0.1");
+        assertTagExists("more-utils-10.0.1");
+        assertTagExists("deep-dependencies-aggregator-1.0.1");
+
+        testProject.mvn("dependency:purge-local-repository -DactTransitively=false -DreResolve=false " +
+            "-DmanualInclude=com.github.danielflower.mavenplugins.testprojects.deepdependencies:console-app");
+        List<String> secondBuildOutput = testProject.mvnRelease("2", "-DnoChangesAction=ReleaseNone");
+        assertThat(secondBuildOutput, noneOf(containsString("No changes have been detected in any modules so will not perform release")));
+        assertTagExists("console-app-3.2.2");
+        assertTagDoesNotExist("parent-module-1.2.3.2");
+        assertTagDoesNotExist("core-utils-2.0.2");
+        assertTagDoesNotExist("more-utils-10.0.2");
+        assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
+
+    }
+
+    @Test
     public void ifThereHaveBeenNoChangesThenCanOptToFailTheBuild() throws Exception {
         List<String> firstBuildOutput = testProject.mvnRelease("1");
         assertThat(firstBuildOutput, noneOf(containsString("No changes have been detected in any modules so will not perform release")));


### PR DESCRIPTION
Add feature of forcing a release of a module(s) when no change is detected to it but the respective artifact cannot be resolved using both local and remote repos.

- always enabled, could be used with a flag / property and maybe only when NoChangesAction=ReleaseNone