### PR TITLE
support using tags in local repository, not fetching remotely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
+before_install:
+  - "export M2_HOME=/usr/local/maven"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.danielflower.mavenplugins</groupId>
     <artifactId>multi-module-maven-release-plugin</artifactId>
-    <version>2.1-SNAPSHOT</version> <!-- When changing also update scaffolding.TestProject.PLUGIN_VERSION_FOR_TESTS and add to src/site/markdown/changelog.md -->
+    <version>2.2-SNAPSHOT</version> <!-- When changing also update scaffolding.TestProject.PLUGIN_VERSION_FOR_TESTS and add to src/site/markdown/changelog.md -->
 
     <name>The Multi Module Maven Release Plugin</name>
     <description>A maven release plugin built for multi-maven-module git repositories allowing continuous deployment

--- a/src/main/java/com/github/danielflower/mavenplugins/release/BaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/BaseMojo.java
@@ -3,6 +3,7 @@ package com.github.danielflower.mavenplugins.release;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.model.Scm;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -137,6 +138,14 @@ public abstract class BaseMojo extends AbstractMojo {
 	@Parameter(property = "passphrase")
 	private String passphrase;
 
+    /**
+     * Fetch tags from remote repository to determine the next build number. If
+     * false, then tags from the local repository will be used instead. Make
+     * sure they are up to date to avoid problems.
+     */
+    @Parameter(alias = "pullTags", property = "pull", defaultValue = "true")
+    protected boolean pullTags;
+
     final void setSettings(final Settings settings) {
 		this.settings = settings;
 	}
@@ -197,4 +206,22 @@ public abstract class BaseMojo extends AbstractMojo {
         log.error("");
         throw new MojoExecutionException(terseMessage);
     }
+
+    protected static String getRemoteUrlOrNullIfNoneSet(Scm originalScm, Scm actualScm) throws ValidationException {
+        if (originalScm == null) {
+            // No scm was specified, so don't inherit from any parent poms as they are probably used in different git repos
+            return null;
+        }
+
+        // There is an SCM specified, so the actual SCM with derived values is used in case (so that variables etc are interpolated)
+        String remote = actualScm.getDeveloperConnection();
+        if (remote == null) {
+            remote = actualScm.getConnection();
+        }
+        if (remote == null) {
+            return null;
+        }
+        return GitHelper.scmUrlToRemote(remote);
+    }
+
 }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/GitOperations.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/GitOperations.java
@@ -1,0 +1,7 @@
+package com.github.danielflower.mavenplugins.release;
+
+public enum GitOperations {
+
+    PULL_TAGS, PUSH_TAGS;
+
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/release/LocalGitRepo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/LocalGitRepo.java
@@ -20,13 +20,88 @@ import static com.github.danielflower.mavenplugins.release.FileUtils.pathOf;
 public class LocalGitRepo {
 
     public final Git git;
-    private final String remoteUrl;
     private boolean hasReverted = false; // A premature optimisation? In the normal case, file reverting occurs twice, which this bool prevents
-    private Collection<Ref> remoteTags;
+    private Collection<Ref> tags;
 
-    LocalGitRepo(Git git, String remoteUrl) {
+    private final TagFetcher tagFetcher;
+    private final TagPusher tagPusher;
+
+    public static class Builder {
+
+        private Set<GitOperations> operationsAllowed = EnumSet.allOf(GitOperations.class);
+        private String remoteGitUrl;
+
+        /**
+         * Flag for which remote Git operations are permitted. Local values will
+         * be substituted if remote operations are forbidden; this means the
+         * local copy of the repository must be up to date!
+         */
+        public Builder remoteGitOperationsAllowed(Set<GitOperations> operationsAllowed) {
+            this.operationsAllowed = EnumSet.copyOf(operationsAllowed);
+            return this;
+        }
+
+        /**
+         * Overrides the URL of remote Git repository.
+         */
+        public Builder remoteGitUrl(String remoteUrl) {
+            this.remoteGitUrl = remoteUrl;
+            return this;
+        }
+
+        /**
+         * Uses the current working dir to open the Git repository.
+         * @throws ValidationException if anything goes wrong
+         */
+        public LocalGitRepo buildFromCurrentDir() throws ValidationException {
+            Git git;
+            File gitDir = new File(".");
+            try {
+                git = Git.open(gitDir);
+            } catch (RepositoryNotFoundException rnfe) {
+                String fullPathOfCurrentDir = pathOf(gitDir);
+                File gitRoot = getGitRootIfItExistsInOneOfTheParentDirectories(new File(fullPathOfCurrentDir));
+                String summary;
+                List<String> messages = new ArrayList<String>();
+                if (gitRoot == null) {
+                    summary = "Releases can only be performed from Git repositories.";
+                    messages.add(summary);
+                    messages.add(fullPathOfCurrentDir + " is not a Git repository.");
+                } else {
+                    summary = "The release plugin can only be run from the root folder of your Git repository";
+                    messages.add(summary);
+                    messages.add(fullPathOfCurrentDir + " is not the root of a Gir repository");
+                    messages.add("Try running the release plugin from " + pathOf(gitRoot));
+                }
+                throw new ValidationException(summary, messages);
+            } catch (Exception e) {
+                throw new ValidationException("Could not open git repository. Is " + pathOf(gitDir) + " a git repository?", Arrays.asList("Exception returned when accessing the git repo:", e.toString()));
+            }
+
+            TagFetcher tagFetcher;
+            TagPusher tagPusher;
+
+            if (operationsAllowed.contains(GitOperations.PULL_TAGS)) {
+                tagFetcher = new RemoteTagFetcher(git, remoteGitUrl);
+            } else {
+                tagFetcher = new LocalTagFetcher(git);
+            }
+
+            if (operationsAllowed.contains(GitOperations.PUSH_TAGS)) {
+                tagPusher = new RemoteTagPusher(git, remoteGitUrl);
+            } else {
+                tagPusher = new LocalTagPusher(git);
+            }
+
+            return new LocalGitRepo(git, tagFetcher, tagPusher);
+        }
+
+    }
+
+    LocalGitRepo(Git git, TagFetcher tagFetcher, TagPusher tagPusher) {
         this.git = git;
-        this.remoteUrl = remoteUrl;
+        this.tagFetcher = tagFetcher;
+        this.tagPusher = tagPusher;
     }
 
     public void errorIfNotClean() throws ValidationException {
@@ -96,54 +171,8 @@ public class LocalGitRepo {
         return GitHelper.hasLocalTag(git, tagName);
     }
 
-    public void tagRepoAndPush(AnnotatedTag tag) throws GitAPIException {
-        Ref tagRef = tagRepo(tag);
-        pushTag(tagRef);
-    }
-
-    private void pushTag(Ref tagRef) throws GitAPIException {
-        PushCommand pushCommand = git.push().add(tagRef);
-        if (remoteUrl != null) {
-            pushCommand.setRemote(remoteUrl);
-        }
-        pushCommand.call();
-    }
-
-    public Ref tagRepo(AnnotatedTag tag) throws GitAPIException {
-        Ref tagRef = tag.saveAtHEAD(git);
-        return tagRef;
-    }
-
-    /**
-     * Uses the current working dir to open the Git repository.
-     * @param remoteUrl The value in pom.scm.connection or null if none specified, in which case the default remote is used.
-     * @throws ValidationException if anything goes wrong
-     */
-    public static LocalGitRepo fromCurrentDir(String remoteUrl) throws ValidationException {
-        Git git;
-        File gitDir = new File(".");
-        try {
-            git = Git.open(gitDir);
-        } catch (RepositoryNotFoundException rnfe) {
-            String fullPathOfCurrentDir = pathOf(gitDir);
-            File gitRoot = getGitRootIfItExistsInOneOfTheParentDirectories(new File(fullPathOfCurrentDir));
-            String summary;
-            List<String> messages = new ArrayList<String>();
-            if (gitRoot == null) {
-                summary = "Releases can only be performed from Git repositories.";
-                messages.add(summary);
-                messages.add(fullPathOfCurrentDir + " is not a Git repository.");
-            } else {
-                summary = "The release plugin can only be run from the root folder of your Git repository";
-                messages.add(summary);
-                messages.add(fullPathOfCurrentDir + " is not the root of a Gir repository");
-                messages.add("Try running the release plugin from " + pathOf(gitRoot));
-            }
-            throw new ValidationException(summary, messages);
-        } catch (Exception e) {
-            throw new ValidationException("Could not open git repository. Is " + pathOf(gitDir) + " a git repository?", Arrays.asList("Exception returned when accessing the git repo:", e.toString()));
-        }
-        return new LocalGitRepo(git, remoteUrl);
+    public void tagAndPushRepo(Collection<AnnotatedTag> tags) throws GitAPIException {
+        tagPusher.pushTags(tags);
     }
 
     private static File getGitRootIfItExistsInOneOfTheParentDirectories(File candidateDir) {
@@ -156,17 +185,17 @@ public class LocalGitRepo {
         return null;
     }
 
-    public List<String> remoteTagsFrom(List<AnnotatedTag> annotatedTags) throws GitAPIException {
+    public List<String> tagsFrom(List<AnnotatedTag> annotatedTags) throws GitAPIException {
         List<String> tagNames = new ArrayList<String>();
         for (AnnotatedTag annotatedTag : annotatedTags) {
             tagNames.add(annotatedTag.name());
         }
-        return getRemoteTags(tagNames);
+        return getTags(tagNames);
     }
 
-    public List<String> getRemoteTags(List<String> tagNamesToSearchFor) throws GitAPIException {
+    public List<String> getTags(List<String> tagNamesToSearchFor) throws GitAPIException {
         List<String> results = new ArrayList<String>();
-        Collection<Ref> remoteTags = allRemoteTags();
+        Collection<Ref> remoteTags = allTags();
         for (Ref remoteTag : remoteTags) {
             for (String proposedTag : tagNamesToSearchFor) {
                 if (remoteTag.getName().equals("refs/tags/" + proposedTag)) {
@@ -177,14 +206,103 @@ public class LocalGitRepo {
         return results;
     }
 
-    public Collection<Ref> allRemoteTags() throws GitAPIException {
-        if (remoteTags == null) {
-            LsRemoteCommand lsRemoteCommand = git.lsRemote().setTags(true).setHeads(false);
-            if (remoteUrl != null) {
-                lsRemoteCommand.setRemote(remoteUrl);
-            }
-            remoteTags = lsRemoteCommand.call();
+    public Collection<Ref> allTags() throws GitAPIException {
+        if (tags == null) {
+            tags = this.tagFetcher.getTags();
         }
-        return remoteTags;
+
+        return tags;
     }
+}
+
+interface TagFetcher {
+
+    public Collection<Ref> getTags() throws GitAPIException;
+
+}
+
+class RemoteTagFetcher implements TagFetcher {
+
+    private final Git git;
+    private final String remoteUrl;
+
+    public RemoteTagFetcher(Git git, String remoteUrl) {
+        this.git = git;
+        this.remoteUrl = remoteUrl;
+    }
+
+    @Override
+    public Collection<Ref> getTags() throws GitAPIException {
+        LsRemoteCommand lsRemoteCommand = git.lsRemote().setTags(true).setHeads(false);
+        if (remoteUrl != null) {
+            lsRemoteCommand.setRemote(remoteUrl);
+        }
+
+        return lsRemoteCommand.call();
+   }
+
+}
+
+class LocalTagFetcher implements TagFetcher {
+
+    private final Git git;
+
+    public LocalTagFetcher(Git git) {
+        this.git = git;
+    }
+
+    @Override
+    public Collection<Ref> getTags() throws GitAPIException {
+        return git.tagList().call();
+    }
+
+}
+
+interface TagPusher {
+
+    public void pushTags(Collection<AnnotatedTag> tags) throws GitAPIException;
+
+}
+
+class RemoteTagPusher implements TagPusher {
+
+    private final Git git;
+    private final String remoteUrl;
+
+    public RemoteTagPusher(Git git, String remoteUrl) {
+        this.git = git;
+        this.remoteUrl = remoteUrl;
+    }
+
+    @Override
+    public void pushTags(Collection<AnnotatedTag> tags) throws GitAPIException {
+        PushCommand pushCommand = git.push();
+        if (remoteUrl != null) {
+            pushCommand.setRemote(remoteUrl);
+        }
+
+        for (AnnotatedTag tag : tags) {
+            pushCommand.add(tag.saveAtHEAD(git));
+        }
+
+        pushCommand.call();
+    }
+
+}
+
+class LocalTagPusher implements TagPusher {
+
+    private final Git git;
+
+    public LocalTagPusher(Git git) {
+        this.git = git;
+    }
+
+    @Override
+    public void pushTags(Collection<AnnotatedTag> tags) throws GitAPIException {
+        for (AnnotatedTag tag : tags) {
+            tag.saveAtHEAD(git);
+        }
+    }
+
 }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/NextMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/NextMojo.java
@@ -8,6 +8,8 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 
@@ -32,7 +34,16 @@ public class NextMojo extends BaseMojo {
         try {
             configureJsch(log);
 
-            LocalGitRepo repo = LocalGitRepo.fromCurrentDir(ReleaseMojo.getRemoteUrlOrNullIfNoneSet(project.getOriginalModel().getScm(), project.getModel().getScm()));
+            Set<GitOperations> gitOperations = EnumSet.noneOf(GitOperations.class);
+            if (pullTags) {
+                gitOperations.add(GitOperations.PULL_TAGS);
+            }
+
+            LocalGitRepo repo = new LocalGitRepo.Builder()
+                .remoteGitOperationsAllowed(gitOperations)
+                .remoteGitUrl(getRemoteUrlOrNullIfNoneSet(project.getOriginalModel().getScm(),
+                                                          project.getModel().getScm()))
+                .buildFromCurrentDir();
             ResolverWrapper resolverWrapper = new ResolverWrapper(factory, artifactResolver, remoteRepositories, localRepository);
             Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction, resolverWrapper, versionNamer);
             if (reactor == null) {

--- a/src/main/java/com/github/danielflower/mavenplugins/release/Reactor.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/Reactor.java
@@ -117,7 +117,7 @@ public class Reactor {
     }
 
     private static Collection<Long> getRemoteBuildNumbers(LocalGitRepo gitRepo, String artifactId, String versionWithoutBuildNumber) throws GitAPIException {
-        Collection<Ref> remoteTagRefs = gitRepo.allRemoteTags();
+        Collection<Ref> remoteTagRefs = gitRepo.allTags();
         Collection<Long> remoteBuildNumbers = new ArrayList<Long>();
         String tagWithoutBuildNumber = artifactId + "-" + versionWithoutBuildNumber;
         for (Ref remoteTagRef : remoteTagRefs) {

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+### 2.2.0
+
+* Can set `pullTags=false` to prevent tags being pulled, in environments where (e.g.) your build lacks
+remote access credentials. Ensure your local repository is already up to date with tags!
+
 ### 2.1.3
 
 * Modules will be released if they cannot be resolved, even if it looks like it hasn't been changed before. See

--- a/src/test/java/e2e/SingleModuleTest.java
+++ b/src/test/java/e2e/SingleModuleTest.java
@@ -100,4 +100,18 @@ public class SingleModuleTest {
         return git.getRepository().getRef("HEAD").getObjectId();
     }
 
+    @Test
+    public void originTagsNotConsultedWithoutPull() throws Exception {
+        testProject.mvn("releaser:release");
+
+        AnnotatedTag.create("single-module-1.0.2", "1.0", 2).saveAtHEAD(testProject.local);
+        AnnotatedTag.create("single-module-1.0.5", "1.0", 5).saveAtHEAD(testProject.origin);
+
+        testProject.mvn("-Dpush=false",
+                        "-Dpull=false",
+                        "releaser:release");
+        assertThat(testProject.local, hasTag("single-module-1.0.3"));
+        assertThat(testProject.origin, not(hasTag("single-module-1.0.3")));
+    }
+
 }

--- a/src/test/java/scaffolding/TestProject.java
+++ b/src/test/java/scaffolding/TestProject.java
@@ -19,7 +19,7 @@ import static scaffolding.Photocopier.copyTestProjectToTemporaryLocation;
 public class TestProject {
 
     private static final MvnRunner defaultRunner = new MvnRunner(null);
-    private static final String PLUGIN_VERSION_FOR_TESTS = "2.1-SNAPSHOT";
+    private static final String PLUGIN_VERSION_FOR_TESTS = "2.2-SNAPSHOT";
     public final File originDir;
     public final Git origin;
 


### PR DESCRIPTION
For constrained build agents, even fetching tags from the remote repository may not be allowed.  Therefore, support disabling the listing of tags from the remote repository, instead using the tags
available in the local repository.  It is up to the user to ensure the local tags are up to date.

This feature is exposed as a new boolean switch `pullTags`, by comparison to existing switch `pushTags`, even though tags aren't actually pulled (just listed).

Internally, refactor the decisions around these switches into strategy objects (how-to-fetch-tags and how-to-push-tags), and create a new builder to more easily assemble them.  This simplifies callers by removing some conditional logic.