### PR TITLE
Allow build numbers to be arbitrary strings or null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.danielflower.mavenplugins</groupId>
     <artifactId>multi-module-maven-release-plugin</artifactId>
-    <version>3.2-SNAPSHOT</version> <!-- When changing also update scaffolding.TestProject.PLUGIN_VERSION_FOR_TESTS and add to src/site/markdown/changelog.md -->
+    <version>3.3-SNAPSHOT</version> <!-- When changing also update scaffolding.TestProject.PLUGIN_VERSION_FOR_TESTS and add to src/site/markdown/changelog.md -->
   
     <name>The Multi Module Maven Release Plugin</name>
     <description>A maven release plugin built for multi-maven-module git repositories allowing continuous deployment
@@ -122,6 +122,15 @@
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-invoker</artifactId>
             <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <!--
+            The maven-dependency-plugin wants this to be listed explicitly as it comes as a transitive dependency
+            of maven-model.
+            -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/src/main/java/com/github/danielflower/mavenplugins/release/AnnotatedTag.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/AnnotatedTag.java
@@ -28,10 +28,10 @@ public class AnnotatedTag {
         this.message = message;
     }
 
-    public static AnnotatedTag create(String name, String version, long buildNumber) {
+    public static AnnotatedTag create(String name, String version, String buildNumber) {
         JSONObject message = new JSONObject();
         message.put(VERSION, version);
-        message.put(BUILD_NUMBER, String.valueOf(buildNumber));
+        message.put(BUILD_NUMBER, buildNumber);
         return new AnnotatedTag(null, name, message);
     }
 
@@ -67,8 +67,8 @@ public class AnnotatedTag {
         return String.valueOf(message.get(VERSION));
     }
 
-    public long buildNumber() {
-        return Long.parseLong(String.valueOf(message.get(BUILD_NUMBER)));
+    public String buildNumber() {
+        return String.valueOf(message.get(BUILD_NUMBER));
     }
 
     public Ref saveAtHEAD(Git git) throws GitAPIException {

--- a/src/main/java/com/github/danielflower/mavenplugins/release/AnnotatedTagFinder.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/AnnotatedTagFinder.java
@@ -46,18 +46,12 @@ class AnnotatedTagFinder {
         return buildNumberOf(versionWithoutBuildNumber, refName) != null;
     }
 
-    Long buildNumberOf(String versionWithoutBuildNumber, String refName) {
+    String buildNumberOf(String versionWithoutBuildNumber, String refName) {
         String tagName = AnnotatedTag.stripRefPrefix(refName);
         String prefix = versionWithoutBuildNumber + versionNamer.getDelimiter();
         if (tagName.startsWith(prefix)) {
-            String end = tagName.substring(prefix.length());
-            try {
-                return Long.parseLong(end);
-            } catch (NumberFormatException e) {
-                return null;
-            }
+            return tagName.substring(prefix.length());
         }
         return null;
     }
-
 }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/Reactor.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/Reactor.java
@@ -1,5 +1,6 @@
 package com.github.danielflower.mavenplugins.release;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -28,7 +29,7 @@ public class Reactor {
         return modulesInBuildOrder;
     }
 
-    public static Reactor fromProjects(Log log, LocalGitRepo gitRepo, MavenProject rootProject, List<MavenProject> projects, Long buildNumber, List<String> modulesToForceRelease, NoChangesAction actionWhenNoChangesDetected, ResolverWrapper resolverWrapper, VersionNamer versionNamer) throws ValidationException, GitAPIException, MojoExecutionException {
+    public static Reactor fromProjects(Log log, LocalGitRepo gitRepo, MavenProject rootProject, List<MavenProject> projects, String buildNumber, List<String> modulesToForceRelease, NoChangesAction actionWhenNoChangesDetected, ResolverWrapper resolverWrapper, VersionNamer versionNamer) throws ValidationException, GitAPIException, MojoExecutionException {
         DiffDetector detector = new TreeWalkingDiffDetector(gitRepo.git.getRepository());
         List<ReleasableModule> modules = new ArrayList<ReleasableModule>();
 
@@ -42,14 +43,14 @@ public class Reactor {
             List<AnnotatedTag> previousTagsForThisModule = annotatedTagFinder.tagsForVersion(gitRepo.git, artifactId, versionWithoutBuildNumber);
 
 
-            Collection<Long> previousBuildNumbers = new ArrayList<Long>();
+            Collection<String> previousBuildNumbers = new ArrayList<>();
             if (previousTagsForThisModule != null) {
                 for (AnnotatedTag previousTag : previousTagsForThisModule) {
                     previousBuildNumbers.add(previousTag.buildNumber());
                 }
             }
 
-            Collection<Long> remoteBuildNumbers = getRemoteBuildNumbers(gitRepo, artifactId, versionWithoutBuildNumber, versionNamer);
+            Collection<String> remoteBuildNumbers = getRemoteBuildNumbers(gitRepo, artifactId, versionWithoutBuildNumber, versionNamer);
             previousBuildNumbers.addAll(remoteBuildNumbers);
 
             VersionName newVersion = versionNamer.name(project.getVersion(), buildNumber, previousBuildNumbers);
@@ -145,14 +146,14 @@ public class Reactor {
         return modelId[0].equals(module.getGroupId()) && modelId[1].equals(module.getArtifactId());
     }
 
-    private static Collection<Long> getRemoteBuildNumbers(LocalGitRepo gitRepo, String artifactId, String versionWithoutBuildNumber, VersionNamer versionNamer) throws GitAPIException {
+    private static Collection<String> getRemoteBuildNumbers(LocalGitRepo gitRepo, String artifactId, String versionWithoutBuildNumber, VersionNamer versionNamer) throws GitAPIException {
         Collection<Ref> remoteTagRefs = gitRepo.allTags();
-        Collection<Long> remoteBuildNumbers = new ArrayList<Long>();
+        Collection<String> remoteBuildNumbers = new ArrayList<>();
         String tagWithoutBuildNumber = artifactId + "-" + versionWithoutBuildNumber;
         AnnotatedTagFinder annotatedTagFinder = new AnnotatedTagFinder(versionNamer);
         for (Ref remoteTagRef : remoteTagRefs) {
             String remoteTagName = remoteTagRef.getName();
-            Long buildNumber = annotatedTagFinder.buildNumberOf(tagWithoutBuildNumber, remoteTagName);
+            String buildNumber = annotatedTagFinder.buildNumberOf(tagWithoutBuildNumber, remoteTagName);
             if (buildNumber != null) {
                 remoteBuildNumbers.add(buildNumber);
             }
@@ -190,20 +191,25 @@ public class Reactor {
         try {
             if (previousTagsForThisModule.size() == 0) return null;
             boolean hasChanged = detector.hasChangedSince(relativePathToModule, project.getModel().getModules(), previousTagsForThisModule);
-            return hasChanged ? null : tagWithHighestBuildNumber(previousTagsForThisModule);
+            return hasChanged ? null : findTagWithHighestBuildNumber(previousTagsForThisModule);
         } catch (Exception e) {
             throw new MojoExecutionException("Error while detecting whether or not " + project.getArtifactId() + " has changed since the last release", e);
         }
     }
 
-    private static AnnotatedTag tagWithHighestBuildNumber(List<AnnotatedTag> tags) {
-        AnnotatedTag cur = null;
+    // Ignores any tags with non-numeric build numbers and finds the one with the largest build number among the others.
+    // The tags are guaranteed to be for the same /business version/ i.e. it's likely a small list.
+    private static AnnotatedTag findTagWithHighestBuildNumber(List<AnnotatedTag> tags) {
+        AnnotatedTag tagWithHighestBuildNumber = null;
         for (AnnotatedTag tag : tags) {
-            if (cur == null || tag.buildNumber() > cur.buildNumber()) {
-                cur = tag;
+            if(StringUtils.isNumeric(tag.buildNumber())) {
+                if (tagWithHighestBuildNumber == null ||
+                    Long.parseLong(tag.buildNumber()) > Long.parseLong(tagWithHighestBuildNumber.buildNumber())) {
+                    tagWithHighestBuildNumber = tag;
+                }
             }
         }
-        return cur;
+        return tagWithHighestBuildNumber;
     }
 
     public ReleasableModule findByLabel(String label) {

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleasableModule.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleasableModule.java
@@ -44,7 +44,7 @@ public class ReleasableModule {
         return version.businessVersion();
     }
 
-    public long getBuildNumber() {
+    public String getBuildNumber() {
         return version.buildNumber();
     }
 

--- a/src/main/java/com/github/danielflower/mavenplugins/release/VersionName.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/VersionName.java
@@ -1,12 +1,15 @@
 package com.github.danielflower.mavenplugins.release;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class VersionName {
     private final String version;
-    private final long buildNumber;
+    private final String buildNumber;
     private final String developmentVersion;
     private final String delimiter;
+    private final String releaseVersion;
 
-    public VersionName(String developmentVersion, String version, long buildNumber, String delimiter) {
+    public VersionName(String developmentVersion, String version, String buildNumber, String delimiter) {
         Guard.notBlank("developmentVersion", developmentVersion);
         Guard.notBlank("version", version);
         Guard.notNull("buildNumber", buildNumber);
@@ -14,20 +17,21 @@ public class VersionName {
         this.buildNumber = buildNumber;
         this.developmentVersion = developmentVersion;
         this.delimiter = delimiter;
+        this.releaseVersion = buildNumber.length() > 0 ? version + delimiter + buildNumber : version;
     }
 
-    public VersionName(String developmentVersion, String version, long buildNumber) {
+    public VersionName(String developmentVersion, String version, String buildNumber) {
         this(developmentVersion, version, buildNumber, ".");
     }
     
     /**
-     * For example, "1.0" if the development version is "1.0-SNAPSHOT"
+     * For example, "1.0" if the development version is "1.0-SNAPSHOT".
      */
     public String businessVersion() {
         return version;
     }
 
-    public long buildNumber() {
+    public String buildNumber() {
         return buildNumber;
     }
 
@@ -42,6 +46,6 @@ public class VersionName {
      * The business version with the build number appended, e.g. "1.0.1"
      */
     public String releaseVersion() {
-        return version + delimiter + buildNumber;
+        return releaseVersion;
     }
 }

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+### 3.3.0
+
+* Allow build numbers to be arbitrary strings or null, #75
+
 ### 3.2.0
 
 * Added support for processing version properties e.g. `<version>${foo.version}</version>`

--- a/src/test/java/com/github/danielflower/mavenplugins/release/AnnotatedTagFinderTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/AnnotatedTagFinderTest.java
@@ -22,22 +22,22 @@ public class AnnotatedTagFinderTest {
     public void findsTheLatestCommitWhereThereHaveBeenNoBranches() throws Exception {
         TestProject project = TestProject.independentVersionsProject();
 
-        AnnotatedTag tag1 = saveFileInModule(project, "console-app", "1.2", 3);
-        AnnotatedTag tag2 = saveFileInModule(project, "core-utils", "2", 0);
-        AnnotatedTag tag3 = saveFileInModule(project, "console-app", "1.2", 4);
+        AnnotatedTag tag1 = saveFileInModule(project, "console-app", "1.2", "3");
+        AnnotatedTag tag2 = saveFileInModule(project, "core-utils", "2", "0");
+        AnnotatedTag tag3 = saveFileInModule(project, "console-app", "1.2", "4");
 
         assertThat(annotatedTagFinder.tagsForVersion(project.local, "console-app", "1.3"), hasSize(0));
         assertThat(annotatedTagFinder.tagsForVersion(project.local, "console-app", "1.2"), containsInAnyOrder(tag1, tag3));
         assertThat(annotatedTagFinder.tagsForVersion(project.local, "core-utils", "2"), contains(tag2));
     }
 
-    static AnnotatedTag saveFileInModule(TestProject project, String moduleName, String version, long buildNumber) throws IOException, GitAPIException {
+    static AnnotatedTag saveFileInModule(TestProject project, String moduleName, String version, String buildNumber) throws IOException, GitAPIException {
         project.commitRandomFile(moduleName);
         String nameForTag = moduleName.equals(".") ? "root" : moduleName;
         return tagLocalRepo(project, nameForTag + "-" + version + versionNamer.getDelimiter() + buildNumber, version, buildNumber);
     }
 
-    private static AnnotatedTag tagLocalRepo(TestProject project, String tagName, String version, long buildNumber) throws GitAPIException {
+    private static AnnotatedTag tagLocalRepo(TestProject project, String tagName, String version, String buildNumber) throws GitAPIException {
         AnnotatedTag tag = AnnotatedTag.create(tagName, version, buildNumber);
         tag.saveAtHEAD(project.local);
         return tag;
@@ -54,10 +54,10 @@ public class AnnotatedTagFinderTest {
     @Test
     public void returnsMultipleTagsOnASingleCommit() throws IOException, GitAPIException, MojoExecutionException {
         TestProject project = TestProject.independentVersionsProject();
-        saveFileInModule(project, "console-app", "1.2", 1);
-        AnnotatedTag tag1 = tagLocalRepo(project, "console-app-1.1.1.1", "1.1.1", 1);
-        AnnotatedTag tag3 = tagLocalRepo(project, "console-app-1.1.1.3", "1.1.1", 3);
-        AnnotatedTag tag2 = tagLocalRepo(project, "console-app-1.1.1.2", "1.1.1", 2);
+        saveFileInModule(project, "console-app", "1.2", "1");
+        AnnotatedTag tag1 = tagLocalRepo(project, "console-app-1.1.1.1", "1.1.1", "1");
+        AnnotatedTag tag3 = tagLocalRepo(project, "console-app-1.1.1.3", "1.1.1", "3");
+        AnnotatedTag tag2 = tagLocalRepo(project, "console-app-1.1.1.2", "1.1.1", "2");
         List<AnnotatedTag> annotatedTags = annotatedTagFinder.tagsForVersion(project.local, "console-app", "1.1.1");
         assertThat(annotatedTags, containsInAnyOrder(tag1, tag2, tag3));
     }
@@ -65,7 +65,7 @@ public class AnnotatedTagFinderTest {
     @Test
     public void versionNamerCaresNotForOrderOfTags() throws ValidationException {
         VersionNamer versionNamer = new VersionNamer();
-        VersionName name = versionNamer.name("1.1.1", null, asList(1L, 3L, 2L));
+        VersionName name = versionNamer.name("1.1.1", null, asList("1", "3", "2"));
         assertThat(name.releaseVersion(), equalTo("1.1.1.4"));
     }
 
@@ -76,15 +76,15 @@ public class AnnotatedTagFinderTest {
         // This should actually be implemented with a parameterized JUnit test but since this class isn't set up for
         // that yet we'll use our own data-driven harness.
         Arrays.asList(new Object[][]{
+            new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0-1", "1"},    // proper match with expected delimiter
+            new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0-A", "A"},    // non-numeric build number
             new Object[]{"libs-1.0.0", refPrefix + "foo-1.0.0-1", null},    // artifact ID does not match -> expect null
-            new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0-1", 1L},     // proper match with expected delimiter
             new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0.1", null},   // no delimiter match
             new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0@1", null},   // no delimiter match
-            new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0-A", null}    // format exception on build number
         })
         .forEach(dataSet -> {
             final Object expectedBuildNumber = dataSet[2];
-            final Long buildNumber = tagFinder.buildNumberOf(dataSet[0].toString(), dataSet[1].toString());
+            final String buildNumber = tagFinder.buildNumberOf(dataSet[0].toString(), dataSet[1].toString());
             assertThat(buildNumber, is(expectedBuildNumber));
         });
     }

--- a/src/test/java/com/github/danielflower/mavenplugins/release/AnnotatedTagTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/AnnotatedTagTest.java
@@ -12,25 +12,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AnnotatedTagTest {
     @Test
-    public void gettersReturnValuesPassedIn() throws Exception {
+    public void gettersReturnValuesPassedIn() {
         // yep, testing getters... but only because it isn't a simple POJO
-        AnnotatedTag tag = AnnotatedTag.create("my-name", "the-version", 2134);
+        AnnotatedTag tag = AnnotatedTag.create("my-name", "the-version", "2134");
         assertThat(tag.name(), equalTo("my-name"));
         assertThat(tag.version(), equalTo("the-version"));
-        assertThat(tag.buildNumber(), equalTo(2134L));
+        assertThat(tag.buildNumber(), equalTo("2134"));
     }
 
     @Test
     public void aTagCanBeCreatedFromAGitTag() throws GitAPIException, IOException {
         TestProject project = TestProject.singleModuleProject();
-        AnnotatedTag tag = AnnotatedTag.create("my-name", "the-version", 2134);
+        AnnotatedTag tag = AnnotatedTag.create("my-name", "the-version", "2134");
         tag.saveAtHEAD(project.local);
 
         Ref ref = project.local.tagList().call().get(0);
         AnnotatedTag inflatedTag = AnnotatedTag.fromRef(project.local.getRepository(), ref);
         assertThat(inflatedTag.name(), equalTo("my-name"));
         assertThat(inflatedTag.version(), equalTo("the-version"));
-        assertThat(inflatedTag.buildNumber(), equalTo(2134L));
+        assertThat(inflatedTag.buildNumber(), equalTo("2134"));
     }
 
     @Test
@@ -42,7 +42,7 @@ public class AnnotatedTagTest {
         AnnotatedTag inflatedTag = AnnotatedTag.fromRef(project.local.getRepository(), ref);
         assertThat(inflatedTag.name(), equalTo("my-name-1.0.2"));
         assertThat(inflatedTag.version(), equalTo("0"));
-        assertThat(inflatedTag.buildNumber(), equalTo(0L));
+        assertThat(inflatedTag.buildNumber(), equalTo("0"));
     }
 
 }

--- a/src/test/java/com/github/danielflower/mavenplugins/release/DiffDetectorTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/DiffDetectorTest.java
@@ -18,9 +18,9 @@ public class DiffDetectorTest {
     public void canDetectIfFilesHaveBeenChangedForAModuleSinceSomeSpecificTag() throws Exception {
         TestProject project = TestProject.independentVersionsProject();
 
-        AnnotatedTag tag1 = saveFileInModule(project, "console-app", "1.2", 3);
-        AnnotatedTag tag2 = saveFileInModule(project, "core-utils", "2", 0);
-        AnnotatedTag tag3 = saveFileInModule(project, "console-app", "1.2", 4);
+        AnnotatedTag tag1 = saveFileInModule(project, "console-app", "1.2", "3");
+        AnnotatedTag tag2 = saveFileInModule(project, "core-utils", "2", "0");
+        AnnotatedTag tag3 = saveFileInModule(project, "console-app", "1.2", "4");
 
         DiffDetector detector = new TreeWalkingDiffDetector(project.local.getRepository());
 
@@ -32,12 +32,12 @@ public class DiffDetectorTest {
     @Test
     public void canDetectThingsInTheRoot() throws IOException, GitAPIException {
         TestProject simple = TestProject.singleModuleProject();
-        AnnotatedTag tag1 = saveFileInModule(simple, ".", "1.0", 1);
+        AnnotatedTag tag1 = saveFileInModule(simple, ".", "1.0", "1");
         simple.commitRandomFile(".");
         DiffDetector detector = new TreeWalkingDiffDetector(simple.local.getRepository());
         assertThat(detector.hasChangedSince(".", noChildModules(), asList(tag1)), is(true));
 
-        AnnotatedTag tag2 = saveFileInModule(simple, ".", "1.0", 2);
+        AnnotatedTag tag2 = saveFileInModule(simple, ".", "1.0", "2");
         assertThat(detector.hasChangedSince(".", noChildModules(), asList(tag2)), is(false));
     }
 
@@ -45,9 +45,9 @@ public class DiffDetectorTest {
     public void canDetectChangesAfterTheLastTag() throws IOException, GitAPIException {
         TestProject project = TestProject.independentVersionsProject();
 
-        saveFileInModule(project, "console-app", "1.2", 3);
-        saveFileInModule(project, "core-utils", "2", 0);
-        AnnotatedTag tag3 = saveFileInModule(project, "console-app", "1.2", 4);
+        saveFileInModule(project, "console-app", "1.2", "3");
+        saveFileInModule(project, "core-utils", "2", "0");
+        AnnotatedTag tag3 = saveFileInModule(project, "console-app", "1.2", "4");
         project.commitRandomFile("console-app");
 
         DiffDetector detector = new TreeWalkingDiffDetector(project.local.getRepository());
@@ -58,7 +58,7 @@ public class DiffDetectorTest {
     public void canIgnoreChangesInModuleFolders() throws IOException, GitAPIException {
         TestProject project = TestProject.nestedProject();
 
-        AnnotatedTag tag1 = saveFileInModule(project, "server-modules", "1.0.2.4", 0);
+        AnnotatedTag tag1 = saveFileInModule(project, "server-modules", "1.0.2.4", "0");
         project.commitRandomFile("server-modules/server-module-a");
 
         DiffDetector detector = new TreeWalkingDiffDetector(project.local.getRepository());
@@ -70,7 +70,7 @@ public class DiffDetectorTest {
     public void canDetectLocalChangesWithModuleFolders() throws IOException, GitAPIException {
         TestProject project = TestProject.nestedProject();
 
-        AnnotatedTag tag1 = saveFileInModule(project, "server-modules", "1.0.2.4", 0);
+        AnnotatedTag tag1 = saveFileInModule(project, "server-modules", "1.0.2.4", "0");
         project.commitRandomFile("server-modules");
 
         DiffDetector detector = new TreeWalkingDiffDetector(project.local.getRepository());

--- a/src/test/java/com/github/danielflower/mavenplugins/release/LocalGitRepoTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/LocalGitRepoTest.java
@@ -70,9 +70,9 @@ public class LocalGitRepoTest {
     }
 
     private static List<AnnotatedTag> tags(String... tagNames) {
-        List<AnnotatedTag> tags = new ArrayList<AnnotatedTag>();
+        List<AnnotatedTag> tags = new ArrayList<>();
         for (String tagName : tagNames) {
-            tags.add(AnnotatedTag.create(tagName, "1", 0));
+            tags.add(AnnotatedTag.create(tagName, "1", "0"));
         }
         return tags;
     }

--- a/src/test/java/com/github/danielflower/mavenplugins/release/ReactorTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/ReactorTest.java
@@ -49,8 +49,8 @@ public class ReactorTest {
 
     @Test
     public void returnsTheLatestTagIfThereAreChanges() throws MojoExecutionException {
-        AnnotatedTag onePointNine = AnnotatedTag.create("whatever-1.1.9", "1.1", 9);
-        AnnotatedTag onePointTen = AnnotatedTag.create("whatever-1.1.10", "1.1", 10);
+        AnnotatedTag onePointNine = AnnotatedTag.create("whatever-1.1.9", "1.1", "9");
+        AnnotatedTag onePointTen = AnnotatedTag.create("whatever-1.1.10", "1.1", "10");
         assertThat(Reactor.hasChangedSinceLastRelease(asList(onePointNine, onePointTen), new NeverChanged(), new MavenProject(), "whatever"), is(onePointTen));
         assertThat(Reactor.hasChangedSinceLastRelease(asList(onePointTen, onePointNine), new NeverChanged(), new MavenProject(), "whatever"), is(onePointTen));
     }

--- a/src/test/java/com/github/danielflower/mavenplugins/release/ReleasableModuleTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/ReleasableModuleTest.java
@@ -20,18 +20,18 @@ public class ReleasableModuleTest {
     }
 
     @Test
-    public void aReleaseableModuleCanBeCreatedFromAnUnreleasableOne() {
+    public void aReleasableModuleCanBeCreatedFromAnUnreleasableOne() {
         MavenProject project = new MavenProject();
         project.setArtifactId("some-arty");
         project.setGroupId("some-group");
         ReleasableModule first = new ReleasableModule(
-            project, new VersionName("1.2.3-SNAPSHOT", "1.2.3", 12), "1.2.3.11", "somewhere"
+            project, new VersionName("1.2.3-SNAPSHOT", "1.2.3", "12"), "1.2.3.11", "somewhere"
         );
         assertThat(first.willBeReleased(), is(false));
 
         ReleasableModule changed = first.createReleasableVersion();
         assertThat(changed.getArtifactId(), equalTo("some-arty"));
-        assertThat(changed.getBuildNumber(), equalTo(12L));
+        assertThat(changed.getBuildNumber(), equalTo("12"));
         assertThat(changed.getGroupId(), equalTo("some-group"));
         assertThat(changed.getNewVersion(), equalTo("1.2.3.12"));
         assertThat(changed.getProject(), is(project));

--- a/src/test/java/com/github/danielflower/mavenplugins/release/VersionNameTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/VersionNameTest.java
@@ -1,0 +1,49 @@
+package com.github.danielflower.mavenplugins.release;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class VersionNameTest {
+
+    @Parameter
+    public String version;
+
+    @Parameter(1)
+    public String buildNumber;
+
+    @Parameter(2)
+    public String expectedReleaseVersion;
+
+    @Parameters(name = "{0} {1} -> {2}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+            new String[]{"1.0", "5", "1.0-5"},
+            new String[]{"1.0", "", "1.0"}
+            //new String[]{"1.0", null, "1.0"}, // in theory yes, in practice there's a not-null precondition in the VersionName c'tor
+        );
+    }
+
+    @Test
+    public void shouldAppendBuildNumberIfNotEmpty() {
+        // given
+        VersionName versionName = new VersionName("1.0-SNAPSHOT", version, buildNumber, "-");
+
+        // when
+        String releaseVersion = versionName.releaseVersion();
+
+        // then
+        assertThat(releaseVersion, is(expectedReleaseVersion));
+    }
+}

--- a/src/test/java/com/github/danielflower/mavenplugins/release/VersionNamerTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/VersionNamerTest.java
@@ -1,63 +1,93 @@
 package com.github.danielflower.mavenplugins.release;
 
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.fail;
 
+@RunWith(Enclosed.class)
 public class VersionNamerTest {
 
-    private final VersionNamer namer = new VersionNamer();
+    @RunWith(Parameterized.class)
+    public static class Name {
+        @Parameter
+        public String developmentVersion;
 
-    @Test
-    public void removesTheSnapshotAndSticksTheBuildNumberOnTheEnd() throws Exception {
-        assertThat(namer.name("1.0-SNAPSHOT", 123L, null).releaseVersion(), is(equalTo("1.0.123")));
+        @Parameter(1)
+        public String buildNumber;
+
+        @Parameter(2)
+        public Collection<String> previousBuildNumbers;
+
+        @Parameter(3)
+        public String delimiter;
+
+        @Parameter(4)
+        public String expectedReleaseVersion;
+
+        @Parameter(5)
+        public boolean expectException;
+
+        @Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(
+                new Object[]{"1.0-SNAPSHOT", "123", null, null, "1.0.123", false},
+                new Object[]{"1.0-SNAPSHOT", null, new ArrayList<String>(), null, "1.0.0", false},
+                new Object[]{"1.0-SNAPSHOT", null, asList("9", "10", "8"), null, "1.0.11", false},
+                new Object[]{"1.0-SNAPSHOT", null, asList("1", "2", "A", "B"), null, "1.0.3", false},
+                new Object[]{"1.0.0-SNAPSHOT", "123", null, "-", "1.0.0-123", false},
+                new Object[]{"1.0-A : yeah /-SNAPSHOT", "0", null, null, "1.0-A : yeah /.0", true}
+            );
+        }
+
+        @Test
+        public void shouldConsiderPreviousBuildNumbers() {
+            // given
+            VersionNamer namer;
+            if (delimiter == null) {
+                namer = new VersionNamer();
+            } else {
+                namer = new VersionNamer(delimiter);
+            }
+
+            try {
+                // when
+                VersionName name = namer.name(developmentVersion, buildNumber, previousBuildNumbers);
+                if (expectException) {
+                    fail(String.format("Expected exception for development version '%s' but got none.", developmentVersion));
+                }
+                // then
+                assertThat(name.releaseVersion(), is(expectedReleaseVersion));
+            } catch (ValidationException e) {
+                assertThat(e.getMessages(), hasSize(3));
+                assertThat(e.getMessages(), hasItems(
+                    String.format("Sorry, '%s' is not a valid version.", expectedReleaseVersion),
+                    "Please see https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html for tag naming rules."
+                ));
+            }
+        }
     }
 
-    @Test
-    public void ifTheBuildNumberIsNullAndThePreviousBuildNumbersIsEmptyListThenZeroIsUsed() throws Exception {
-        assertThat(namer.name("1.0-SNAPSHOT", null, new ArrayList<Long>()).releaseVersion(), is(equalTo("1.0.0")));
-    }
-
-    @Test
-    public void ifTheBuildNumberIsNullButThereIsAPreviousBuildNumbersThenThatValueIsIncremented() throws Exception {
-        assertThat(namer.name("1.0-SNAPSHOT", null, asList(9L, 10L, 8L)).releaseVersion(), is(equalTo("1.0.11")));
-    }
-
-    @Test
-    public void throwsIfTheVersionWouldNotBeAValidGitTag() {
-        assertThat(errorMessageOf("1.0-A : yeah /-SNAPSHOT", 0),
-            hasItems(
-                "Sorry, '1.0-A : yeah /.0' is not a valid version.",
-                "Please see https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html for tag naming rules."
-            )
-        );
-    }
-
-    @Test
-    public void addsTheBuildWithADash() throws Exception {
-        assertThat(new VersionNamer("-").name("1.0.0-SNAPSHOT", 123L, null).releaseVersion(), is(equalTo("1.0.0-123")));
-    }
-
-    @Test
-    public void getterReturnsDefinedOrDefaultDelimiter() {
-        assertThat(new VersionNamer("-").getDelimiter(), is("-"));
-        assertThat(new VersionNamer("@").getDelimiter(), is("@"));
-        assertThat(new VersionNamer().getDelimiter(), is("."));
-    }
-
-    private List<String> errorMessageOf(String pomVersion, long buildNumber) {
-        try {
-            namer.name(pomVersion, buildNumber, null);
-            throw new AssertionError("Did not throw an error");
-        } catch (ValidationException ex) {
-            return ex.getMessages();
+    public static class GetDelimiter {
+        @Test
+        public void shouldReturnDefinedDelimiterOrDotPerDefault() {
+            assertThat(new VersionNamer("-").getDelimiter(), is("-"));
+            assertThat(new VersionNamer("@").getDelimiter(), is("@"));
+            assertThat(new VersionNamer().getDelimiter(), is("."));
         }
     }
 }

--- a/src/test/java/e2e/NonNumericBuildNumbersTest.java
+++ b/src/test/java/e2e/NonNumericBuildNumbersTest.java
@@ -1,0 +1,94 @@
+package e2e;
+
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import scaffolding.MvnRunner;
+import scaffolding.TestProject;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static scaffolding.ExactCountMatcher.oneOf;
+
+import static scaffolding.TestProject.differentDelimiterProject;
+import static scaffolding.TestProject.emptyBuildNumberInPomProject;
+import static scaffolding.TestProject.singleModuleProject;
+
+/**
+ * Tests behavior when the build number is not a number. It can be alpha-numeric or an empty string in which case it
+ * should be omitted in the release version.
+ */
+@RunWith(Parameterized.class)
+public class NonNumericBuildNumbersTest {
+    @Parameter
+    public String testCaseName;
+
+    @Parameter(1)
+    public TestProject testProject;
+
+    @Parameter(2)
+    public String buildNumber;
+
+    @Parameter(3)
+    public String expectedReleaseVersion;
+
+    @BeforeClass
+    public static void installPluginToLocalRepo() {
+        MvnRunner.installReleasePluginToLocalRepo();
+    }
+
+    @Parameters(name = "{0} -> {3}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+            // The projects used here are arbitrary, you just can't use the same project + build number combination twice
+            new Object[]{"alpha-numeric build number as CLI argument", differentDelimiterProject(), "ABC", "1.0.0-ABC"},
+            new Object[]{"empty build number as CLI argument, ''", differentDelimiterProject(), "''", "1.0.0"},
+            new Object[]{"empty build number as CLI argument, \"\"", singleModuleProject(), "\"\"", "1.0"},
+            // This one is specific because of the <buildNumber> in the POM
+            new Object[]{"empty build number in POM", emptyBuildNumberInPomProject(), null, "1.0.0"}
+        );
+    }
+
+    @Test
+    public void shouldSupportAlphaNumericOrEmptyBuildNumbers() throws Exception {
+        // given the test data
+        List<String> outputLines;
+
+        // when
+        if (buildNumber == null) {
+            outputLines = testProject.mvnRelease();
+        } else {
+            outputLines = testProject.mvnRelease(buildNumber);
+        }
+
+        // then
+        assertMainClassOutputWithReleaseVersion(outputLines);
+        assertJarWithVersionInTargetFolder();
+        assertArtifactInLocalMavenRepo();
+    }
+
+    private void assertMainClassOutputWithReleaseVersion(List<String> outputLines) {
+        assertThat(outputLines, oneOf(containsString("Hello from version " + expectedReleaseVersion + "!")));
+    }
+
+    private void assertArtifactInLocalMavenRepo() throws IOException, MavenInvocationException {
+        MvnRunner.assertArtifactInLocalRepo("com.github.danielflower.mavenplugins.testprojects", testProject.getName(), expectedReleaseVersion);
+    }
+
+    private void assertJarWithVersionInTargetFolder() {
+        String fileName = testProject.getName() + "-" + expectedReleaseVersion + "-package.jar";
+        File jarInTargetFolder = new File(testProject.localDir, "target/" + fileName);
+        assertThat(jarInTargetFolder.exists(), is(true));
+    }
+}

--- a/src/test/java/e2e/SingleModuleTest.java
+++ b/src/test/java/e2e/SingleModuleTest.java
@@ -54,12 +54,12 @@ public class SingleModuleTest {
         testProject.mvn("releaser:release");
         assertThat(testProject.local, hasTag("single-module-1.0.1"));
 
-        AnnotatedTag.create("single-module-1.0.2", "1.0", 2).saveAtHEAD(testProject.local);
+        AnnotatedTag.create("single-module-1.0.2", "1.0", "2").saveAtHEAD(testProject.local);
         testProject.mvn("releaser:release");
         assertThat(testProject.local, hasTag("single-module-1.0.3"));
 
-        AnnotatedTag.create("single-module-1.0.4", "1.0", 4).saveAtHEAD(testProject.origin);
-        AnnotatedTag.create("unrelated-module-1.0.5", "1.0", 5).saveAtHEAD(testProject.origin);
+        AnnotatedTag.create("single-module-1.0.4", "1.0", "4").saveAtHEAD(testProject.origin);
+        AnnotatedTag.create("unrelated-module-1.0.5", "1.0", "5").saveAtHEAD(testProject.origin);
         testProject.mvn("releaser:release");
         assertThat(testProject.local, hasTag("single-module-1.0.5"));
 
@@ -104,8 +104,8 @@ public class SingleModuleTest {
     public void originTagsNotConsultedWithoutPull() throws Exception {
         testProject.mvn("releaser:release");
 
-        AnnotatedTag.create("single-module-1.0.2", "1.0", 2).saveAtHEAD(testProject.local);
-        AnnotatedTag.create("single-module-1.0.5", "1.0", 5).saveAtHEAD(testProject.origin);
+        AnnotatedTag.create("single-module-1.0.2", "1.0", "2").saveAtHEAD(testProject.local);
+        AnnotatedTag.create("single-module-1.0.5", "1.0", "5").saveAtHEAD(testProject.origin);
 
         testProject.mvn("-Dpush=false",
                         "-Dpull=false",

--- a/src/test/java/scaffolding/MvnRunner.java
+++ b/src/test/java/scaffolding/MvnRunner.java
@@ -1,12 +1,14 @@
 package scaffolding;
 
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.shared.invoker.*;
 
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -82,6 +84,8 @@ public class MvnRunner {
 
         int exitCode;
         try {
+            System.out.println(String.format("Running mvn in '%s' with profile(s) '%s' and arguments %s.",
+                workingDir, StringUtils.defaultString(profile), Arrays.toString(arguments)));
             InvocationResult result = invoker.execute(request);
             exitCode = result.getExitCode();
         } catch (Exception e) {
@@ -93,6 +97,8 @@ public class MvnRunner {
             throw new MavenExecutionException(exitCode, output);
         }
 
+        System.out.println("That produced the following output.\n");
+        output.forEach(System.out::println);
         return output;
     }
 

--- a/src/test/java/scaffolding/ReleasableModuleBuilder.java
+++ b/src/test/java/scaffolding/ReleasableModuleBuilder.java
@@ -9,12 +9,12 @@ public class ReleasableModuleBuilder {
 
     private final VersionNamer versionNamer = new VersionNamer();
     MavenProject project = new MavenProject();
-    private long buildNumber = 123;
+    private String buildNumber = "123";
     private String equivalentVersion = null;
     private String relativePathToModule = ".";
 
     public ReleasableModuleBuilder withBuildNumber(long buildNumber) {
-        this.buildNumber = buildNumber;
+        this.buildNumber = String.valueOf(buildNumber);
         return this;
     }
 

--- a/src/test/java/scaffolding/TestProject.java
+++ b/src/test/java/scaffolding/TestProject.java
@@ -19,28 +19,36 @@ import static scaffolding.Photocopier.copyTestProjectToTemporaryLocation;
 public class TestProject {
 
     private static final MvnRunner defaultRunner = new MvnRunner(null);
-    private static final String PLUGIN_VERSION_FOR_TESTS = "3.2-SNAPSHOT";
+    private static final String PLUGIN_VERSION_FOR_TESTS = "3.3-SNAPSHOT";
+    private static final String RELEASE_TARGET = "releaser:release";
+    private static final String NEXT_TARGET = "releaser:next";
 
     public final File originDir;
     public final Git origin;
 
     public final File localDir;
     public final Git local;
+    private final String name;
 
     private final AtomicInteger commitCounter = new AtomicInteger(1);
     private MvnRunner mvnRunner = defaultRunner;
 
-    private TestProject(File originDir, Git origin, File localDir, Git local) {
+    private TestProject(File originDir, Git origin, File localDir, Git local, String name) {
         this.originDir = originDir;
         this.origin = origin;
         this.localDir = localDir;
         this.local = local;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
     }
 
     /**
      * Runs a mvn command against the local repo and returns the console output.
      */
-    public List<String> mvn(String... arguments) throws IOException {
+    public List<String> mvn(String... arguments) {
         return mvnRunner.runMaven(localDir, arguments);
     }
 
@@ -48,18 +56,20 @@ public class TestProject {
         mvnRunner.mavenOpts = mavenOpts;
     }
 
-    public List<String> mvnRelease(String buildNumber) throws IOException, InterruptedException {
-        return mvnRunner.runMaven(localDir,
-            "-DbuildNumber=" + buildNumber,
-            "releaser:release");
+    public List<String> mvnRelease()  {
+        return mvnRunner.runMaven(localDir, RELEASE_TARGET);
     }
 
-    public List<String> mvnRelease(String buildNumber, String...arguments) throws IOException, InterruptedException {
-        return mvnRun("releaser:release", buildNumber, arguments);
+    public List<String> mvnRelease(String buildNumber) {
+        return mvnRunner.runMaven(localDir, "-DbuildNumber=" + buildNumber, RELEASE_TARGET);
     }
 
-    public List<String> mvnReleaserNext(String buildNumber, String...arguments) throws IOException, InterruptedException {
-        return mvnRun("releaser:next", buildNumber, arguments);
+    public List<String> mvnRelease(String buildNumber, String...arguments) {
+        return mvnRun(RELEASE_TARGET, buildNumber, arguments);
+    }
+
+    public List<String> mvnReleaserNext(String buildNumber, String...arguments) {
+        return mvnRun(NEXT_TARGET, buildNumber, arguments);
     }
 
     public TestProject commitRandomFile(String module) throws IOException, GitAPIException {
@@ -106,7 +116,7 @@ public class TestProject {
                 .setURI(originDir.toURI().toString())
                 .call();
 
-            return new TestProject(originDir, origin, localDir, local);
+            return new TestProject(originDir, origin, localDir, local, name);
         } catch (Exception e) {
             throw new RuntimeException("Error while creating copies of the test project", e);
         }
@@ -184,6 +194,10 @@ public class TestProject {
 
     public static TestProject differentDelimiterProject() {
         return project("different-delimiter");
+    }
+
+    public static TestProject emptyBuildNumberInPomProject() {
+        return project("empty-build-number-in-pom");
     }
 
     public void setMvnRunner(MvnRunner mvnRunner) {

--- a/test-projects/empty-build-number-in-pom/.gitignore
+++ b/test-projects/empty-build-number-in-pom/.gitignore
@@ -1,0 +1,6 @@
+target
+.idea/
+*.iml
+.classpath
+.settings
+.project

--- a/test-projects/empty-build-number-in-pom/assembly-descriptor.xml
+++ b/test-projects/empty-build-number-in-pom/assembly-descriptor.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>package</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/test-projects/empty-build-number-in-pom/pom.xml
+++ b/test-projects/empty-build-number-in-pom/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects</groupId>
+    <artifactId>empty-build-number-in-pom</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <!-- This comment is here for a test that ensures comments are not deleted -->
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                    <!-- this signifies an empty string -->
+                    <buildNumber>""</buildNumber>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.google.code.echo-maven-plugin</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <message>Hello from version ${project.version}!</message>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>echo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>assembly-descriptor.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/test-projects/empty-build-number-in-pom/src/main/java/com/github/danielflower/mavenplugins/testproject/singlepom/Main.java
+++ b/test-projects/empty-build-number-in-pom/src/main/java/com/github/danielflower/mavenplugins/testproject/singlepom/Main.java
@@ -1,0 +1,7 @@
+package com.github.danielflower.mavenplugins.testproject.singlepom;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world");
+    }
+}


### PR DESCRIPTION
This required changing the `buildNumber` data type from `long` to `String`. @CDPrete this fixes your issue #75. Hence, your feedback is appreciated.