### PR TITLE
Introduced new configuration for generating released/all modules versions

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
@@ -98,7 +98,14 @@ public class ReleaseMojo extends BaseMojo {
      */
     @Parameter(alias = "pushTags", defaultValue="true", property="push")
     private boolean pushTags;
-    
+
+    /**
+     * <p>
+     *     Reports to generate with updated versions.
+     * </p>
+     */
+    @Parameter(alias = "versionReports")
+    private List<VersionReport> versionReports;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -132,6 +139,12 @@ public class ReleaseMojo extends BaseMojo {
             List<AnnotatedTag> proposedTags = figureOutTagNamesAndThrowIfAlreadyExists(reactor.getModulesInBuildOrder(), repo, modulesToRelease);
 
             List<File> changedFiles = updatePomsAndReturnChangedFiles(log, repo, reactor);
+
+            if (versionReports != null) {
+                for (VersionReport versionReport : versionReports) {
+                    versionReport.generateVersionReport(log, reactor.getModulesInBuildOrder());
+                }
+            }
 
             // Do this before running the maven build in case the build uploads some artifacts and then fails. If it is
             // not tagged in a half-failed build, then subsequent releases will re-use a version that is already in Nexus

--- a/src/main/java/com/github/danielflower/mavenplugins/release/VersionReport.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/VersionReport.java
@@ -1,0 +1,70 @@
+package com.github.danielflower.mavenplugins.release;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.json.simple.JSONObject;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+import static java.lang.String.format;
+
+public class VersionReport {
+
+    /**
+     * File format to use for @versionsReportFilePath
+     */
+    @Parameter
+    private VersionReportFormat versionsReportFormat;
+
+    /**
+     * If true then a report with all versions will be generated.
+     */
+    @Parameter
+    private String versionsReportFilePath;
+
+    /**
+     * If report should contain only released modules or all modules.
+     */
+    @Parameter(alias = "releasedModulesOnly", defaultValue="false")
+    private boolean releasedModulesOnly;
+
+    public void generateVersionReport(Log log, List<ReleasableModule> releasableModules) throws IOException {
+        String res = "";
+        switch (versionsReportFormat) {
+            case FLAT:
+                for (ReleasableModule module : releasableModules) {
+                    if (skipModuleInReport(module)) continue;
+                    res += String.format("%s:%s%n",
+                        module.getArtifactId(), module.getVersionToDependOn());
+                }
+                break;
+            default: //JSON as default
+                JSONObject jsonObject = new JSONObject();
+                for (ReleasableModule module : releasableModules) {
+                    if (skipModuleInReport(module)) continue;
+                    jsonObject.put(module.getArtifactId(), module.getVersionToDependOn());
+                }
+                res = jsonObject.toJSONString();
+                break;
+        }
+
+        if (!res.equals("")) {
+            try (FileWriter file = new FileWriter(versionsReportFilePath, true)) {
+                file.write(res);
+                log.info(format("Successfully written report file - %s", versionsReportFilePath));
+            } catch (IOException e) {
+                log.warn(format("Failed to write report to file %nversionsReportFilePath=%s%ncontent=%s",
+                    versionsReportFilePath, res));
+                throw e;
+            }
+        } else {
+            log.info(format("Nothing to write in report, versionsReportFilePath=%s", versionsReportFilePath));
+        }
+    }
+
+    private boolean skipModuleInReport(ReleasableModule module) {
+        return (releasedModulesOnly && !module.willBeReleased());
+    }
+}

--- a/src/main/java/com/github/danielflower/mavenplugins/release/VersionReport.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/VersionReport.java
@@ -2,6 +2,7 @@ package com.github.danielflower.mavenplugins.release;
 
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 import java.io.FileWriter;
@@ -42,10 +43,17 @@ public class VersionReport {
                 break;
             default: //JSON as default
                 JSONObject jsonObject = new JSONObject();
+                JSONArray releasedModulesArray = new JSONArray();
+
                 for (ReleasableModule module : releasableModules) {
                     if (skipModuleInReport(module)) continue;
-                    jsonObject.put(module.getArtifactId(), module.getVersionToDependOn());
+                    JSONObject releasedModuleObject = new JSONObject();
+                    releasedModuleObject.put("name", module.getArtifactId());
+                    releasedModuleObject.put("version", module.getVersionToDependOn());
+                    releasedModulesArray.add(releasedModuleObject);
                 }
+
+                jsonObject.put("modules", releasedModulesArray);
                 res = jsonObject.toJSONString();
                 break;
         }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/VersionReportFormat.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/VersionReportFormat.java
@@ -1,0 +1,5 @@
+package com.github.danielflower.mavenplugins.release;
+
+public enum VersionReportFormat {
+    JSON, FLAT;
+}

--- a/src/test/java/e2e/VersionsReportTest.java
+++ b/src/test/java/e2e/VersionsReportTest.java
@@ -1,0 +1,70 @@
+package e2e;
+
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import scaffolding.MvnRunner;
+import scaffolding.TestProject;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static scaffolding.ExactCountMatcher.oneOf;
+import static scaffolding.ExactCountMatcher.twoOf;
+
+public class VersionsReportTest {
+
+    final String buildNumber = String.valueOf(System.currentTimeMillis());
+    final String expectedParentVersion = "1.0." + buildNumber;
+    final String expectedCoreVersion = "2.0." + buildNumber;
+    final String expectedAppVersion = "3.2." + buildNumber;
+    final String releasedVersionsReportFlatFileName = "released-report.txt";
+    final String releasedVersionsReportJsonFileName = "released-report.json";
+    final String allVersionsReportJsonFileName = "version-report.json";
+    final List<String> reportedVersions = Arrays.asList(
+        "independent-versions:" + expectedParentVersion,
+        "core-utils:" + expectedCoreVersion,
+        "console-app:" + expectedAppVersion);
+    final TestProject testProject = TestProject.versionReportProject();
+
+    @BeforeClass
+    public static void installPluginToLocalRepo() throws MavenInvocationException {
+        MvnRunner.installReleasePluginToLocalRepo();
+    }
+
+    @Test
+    public void buildsAndInstallsAndTagsAllModules() throws Exception {
+        buildsEachProjectOnceAndOnlyOnce(testProject.mvnRelease(buildNumber));
+        reportsFilesGeneratedWithCorrectVersionsAndFormat();
+    }
+
+    private void reportsFilesGeneratedWithCorrectVersionsAndFormat() throws IOException {
+        List<String> fileLines = Files.readAllLines(new File(testProject.localDir, releasedVersionsReportFlatFileName).toPath(), Charset.defaultCharset());
+        assertTrue(fileLines.size() == reportedVersions.size() && fileLines.containsAll(reportedVersions) && reportedVersions.containsAll(fileLines));
+    }
+
+    private void buildsEachProjectOnceAndOnlyOnce(List<String> commandOutput) {
+        assertThat(
+            commandOutput,
+            allOf(
+                oneOf(containsString("Going to release independent-versions " + expectedParentVersion)),
+                twoOf(containsString("Building independent-versions")), // once for initial build; once for release build
+                oneOf(containsString("Building core-utils")),
+                oneOf(containsString("Building console-app")),
+                oneOf(containsString("The Calculator Test has run")),
+                oneOf(containsString("Successfully written report file - " + releasedVersionsReportFlatFileName)),
+                oneOf(containsString("Successfully written report file - " + releasedVersionsReportJsonFileName)),
+                oneOf(containsString("Successfully written report file - " + allVersionsReportJsonFileName))
+            )
+        );
+    }
+}

--- a/src/test/java/scaffolding/TestProject.java
+++ b/src/test/java/scaffolding/TestProject.java
@@ -159,6 +159,10 @@ public class TestProject {
         return project("independent-versions");
     }
 
+    public static TestProject versionReportProject() {
+        return project("version-report");
+    }
+
     public static TestProject parentAsSibilngProject() {
         return project("parent-as-sibling");
     }

--- a/test-projects/version-report/.gitignore
+++ b/test-projects/version-report/.gitignore
@@ -1,0 +1,6 @@
+target
+.idea/
+*.iml
+.classpath
+.settings
+.project

--- a/test-projects/version-report/console-app/pom.xml
+++ b/test-projects/version-report/console-app/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>independent-versions</artifactId>
+        <groupId>com.github.danielflower.mavenplugins.testprojects.independentversions</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>console-app</artifactId>
+    <version>3.2-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.danielflower.mavenplugins.testprojects.independentversions</groupId>
+            <artifactId>core-utils</artifactId>
+            <version>2.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-projects/version-report/console-app/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/App.java
+++ b/test-projects/version-report/console-app/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/App.java
@@ -1,0 +1,8 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+public class App {
+    public static void main(String[] args) {
+        Calculator calculator = new Calculator();
+        System.out.println("1 + 2 = " + calculator.add(1, 2));
+    }
+}

--- a/test-projects/version-report/core-utils/pom.xml
+++ b/test-projects/version-report/core-utils/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>independent-versions</artifactId>
+        <groupId>com.github.danielflower.mavenplugins.testprojects.independentversions</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>core-utils</artifactId>
+    <version>2.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-projects/version-report/core-utils/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
+++ b/test-projects/version-report/core-utils/src/main/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/Calculator.java
@@ -1,0 +1,9 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+public class Calculator {
+
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+}

--- a/test-projects/version-report/core-utils/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
+++ b/test-projects/version-report/core-utils/src/test/java/com/github/danielflower/mavenplugins/testprojects/versioninheritor/CalculatorTest.java
@@ -1,0 +1,14 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CalculatorTest {
+
+    @Test
+    public void testAdd() throws Exception {
+        Assert.assertEquals(3, new Calculator().add(1, 2));
+        System.out.println("The Calculator Test has run"); // used in a test to assert this has run
+    }
+}

--- a/test-projects/version-report/pom.xml
+++ b/test-projects/version-report/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects.independentversions</groupId>
+    <artifactId>independent-versions</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <modules>
+        <module>core-utils</module>
+        <module>console-app</module>
+    </modules>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <versionReports>
+                        <versionReport>
+                            <versionsReportFilePath>released-report.txt</versionsReportFilePath>
+                            <versionsReportFormat>FLAT</versionsReportFormat>
+                            <releasedModulesOnly>true</releasedModulesOnly>
+                        </versionReport>
+                        <versionReport>
+                            <versionsReportFilePath>released-report.json</versionsReportFilePath>
+                            <versionsReportFormat>JSON</versionsReportFormat>
+                            <releasedModulesOnly>true</releasedModulesOnly>
+                        </versionReport>
+                        <versionReport>
+                            <versionsReportFilePath>version-report.json</versionsReportFilePath>
+                            <versionsReportFormat>JSON</versionsReportFormat>
+                            <releasedModulesOnly>false</releasedModulesOnly>
+                        </versionReport>
+                    </versionReports>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
This PR adds a new configuration for generating reports of released/all modules, this is useful for CI/CD flows where for example we have mono-repo and we want to understand which versions were released, so we can update other things like helm charts or other tasks.