### PR TITLE
Handle plugin dependencies

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/release/PomUpdater.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/PomUpdater.java
@@ -104,6 +104,9 @@ public class PomUpdater {
         if (originalModel.getBuild() != null && originalModel.getBuild().getPlugins() != null) {
             for (Plugin plugin : originalModel.getBuild().getPlugins()) {
                 alterSinglePlugin(errors, searchingFrom, projectProperties, plugin);
+                for (Dependency dependency : plugin.getDependencies()) {
+                    alterSingleDependency(errors, searchingFrom, projectProperties, dependency);
+                }
             }
         }
 
@@ -125,7 +128,7 @@ public class PomUpdater {
         }
         return errors;
     }
-    
+
     private boolean isReleasablePlugin(Plugin plugin) {
         try {
             reactor.find(plugin.getGroupId(), plugin.getArtifactId(), plugin.getVersion());

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -4,6 +4,7 @@ Changelog
 ### 3.6.0
 
 * Latest tagged version from current branch is used for unchanged modules [issue #118 for details](https://github.com/danielflower/multi-module-maven-release-plugin/issues/118)
+* Handle plugin dependencies the same way as "ordinary" dependencies (update version number) 
 
 ### 3.2.0
 

--- a/src/test/java/e2e/PluginDependencyTest.java
+++ b/src/test/java/e2e/PluginDependencyTest.java
@@ -1,0 +1,70 @@
+package e2e;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scaffolding.MvnRunner;
+import scaffolding.TestProject;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static scaffolding.ExactCountMatcher.oneOf;
+import static scaffolding.GitMatchers.hasTag;
+
+public class PluginDependencyTest {
+
+    final TestProject testProject = TestProject.openapiSpecAsPluginDependency();
+
+
+    @BeforeClass
+    public static void installPluginToLocalRepo() {
+        MvnRunner.installReleasePluginToLocalRepo();
+    }
+
+    @Test
+    public void runWithPluginDependencyWithoutCommitInOpenApiSpecShouldSucceed() throws Exception {
+        List<String> output1 = testProject.mvnRelease("1", "-X");
+        assertThat(
+                output1,
+                allOf(
+                        // Make sure that plugin uses the-openapi-spec 1.0.1
+                        oneOf(containsString("Populating class realm plugin>org.openapitools:openapi-generator-maven-plugin")),
+                        oneOf(containsString("Included: com.github.danielflower.mavenplugins.testprojects.openapi-spec-as-plugin-dependency:the-openapi-spec:jar:1.0.1"))
+                )
+        );
+        testProject.commitRandomFile("the-openapi-spec").pushIt();
+        List<String> output2 = testProject.mvnRelease("2", "-X");
+        assertThat(
+                output2,
+                allOf(
+                        // Make sure that plugin uses the-openapi-spec 1.0.2
+                        oneOf(containsString("Populating class realm plugin>org.openapitools:openapi-generator-maven-plugin")),
+                        oneOf(containsString("Included: com.github.danielflower.mavenplugins.testprojects.openapi-spec-as-plugin-dependency:the-openapi-spec:jar:1.0.2"))
+                )
+        );
+
+        // The module in which a new file was committed
+        assertTagExists("the-openapi-spec-1.0.1");
+        assertTagExists("the-openapi-spec-1.0.2");
+
+        // The module in which the module "the-openapi-spec" is used
+        assertTagExists("the-service-impl-1.0.1");
+        assertTagExists("the-service-impl-1.0.2");
+
+        // The parent module
+        assertTagExists("openapi-spec-as-plugin-dependency-aggregator-1.0.1");
+        assertTagDoesNotExist("openapi-spec-as-plugin-dependency-aggregator-1.0.2");
+    }
+
+    private void assertTagExists(String tagName) {
+        assertThat(testProject.local, hasTag(tagName));
+        assertThat(testProject.origin, hasTag(tagName));
+    }
+
+    private void assertTagDoesNotExist(String tagName) {
+        assertThat(testProject.local, not(hasTag(tagName)));
+        assertThat(testProject.origin, not(hasTag(tagName)));
+    }
+
+}

--- a/src/test/java/scaffolding/TestProject.java
+++ b/src/test/java/scaffolding/TestProject.java
@@ -50,15 +50,15 @@ public class TestProject {
 
     public List<String> mvnRelease(String buildNumber) throws IOException, InterruptedException {
         return mvnRunner.runMaven(localDir,
-            "-DbuildNumber=" + buildNumber,
-            "releaser:release");
+                "-DbuildNumber=" + buildNumber,
+                "releaser:release");
     }
 
-    public List<String> mvnRelease(String buildNumber, String...arguments) throws IOException, InterruptedException {
+    public List<String> mvnRelease(String buildNumber, String... arguments) throws IOException, InterruptedException {
         return mvnRun("releaser:release", buildNumber, arguments);
     }
 
-    public List<String> mvnReleaserNext(String buildNumber, String...arguments) throws IOException, InterruptedException {
+    public List<String> mvnReleaserNext(String buildNumber, String... arguments) throws IOException, InterruptedException {
         return mvnRun("releaser:next", buildNumber, arguments);
     }
 
@@ -93,7 +93,7 @@ public class TestProject {
         String[] args = new String[arguments.length + 2];
         args[0] = "-DbuildNumber=" + buildNumber;
         System.arraycopy(arguments, 0, args, 1, arguments.length);
-        args[args.length-1] = goal;
+        args[args.length - 1] = goal;
         return mvnRunner.runMaven(localDir, args);
     }
 
@@ -111,10 +111,10 @@ public class TestProject {
 
             File localDir = Photocopier.folderForSampleProject(name);
             Git local = Git.cloneRepository()
-                .setBare(false)
-                .setDirectory(localDir)
-                .setURI(originDir.toURI().toString())
-                .call();
+                    .setBare(false)
+                    .setDirectory(localDir)
+                    .setURI(originDir.toURI().toString())
+                    .call();
 
             return new TestProject(originDir, origin, localDir, local);
         } catch (Exception e) {
@@ -186,7 +186,7 @@ public class TestProject {
     }
 
     public static TestProject dependencyManagementUsingParentModuleVersionPropertyProject() {
-	    return project("dependencymanagement-using-parent-module-version-property");
+        return project("dependencymanagement-using-parent-module-version-property");
     }
 
     public static TestProject moduleWithTestFailure() {
@@ -196,12 +196,17 @@ public class TestProject {
     public static TestProject moduleWithSnapshotDependencies() {
         return project("snapshot-dependencies");
     }
+
     public static TestProject moduleWithSnapshotDependenciesWithVersionProperties() {
         return project("snapshot-dependencies-with-version-properties");
     }
 
     public static TestProject differentDelimiterProject() {
         return project("different-delimiter");
+    }
+
+    public static TestProject openapiSpecAsPluginDependency() {
+        return project("openapi-spec-as-plugin-dependency");
     }
 
     public void setMvnRunner(MvnRunner mvnRunner) {

--- a/test-projects/openapi-spec-as-plugin-dependency/.gitignore
+++ b/test-projects/openapi-spec-as-plugin-dependency/.gitignore
@@ -1,0 +1,6 @@
+target
+.idea/
+*.iml
+.classpath
+.settings
+.project

--- a/test-projects/openapi-spec-as-plugin-dependency/pom.xml
+++ b/test-projects/openapi-spec-as-plugin-dependency/pom.xml
@@ -5,13 +5,6 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.4</version>
-    <relativePath/> <!-- lookup parent from repository -->
-  </parent>
-
   <groupId>com.github.danielflower.mavenplugins.testprojects.openapi-spec-as-plugin-dependency</groupId>
   <artifactId>openapi-spec-as-plugin-dependency-aggregator</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/test-projects/openapi-spec-as-plugin-dependency/pom.xml
+++ b/test-projects/openapi-spec-as-plugin-dependency/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.3.4</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
+  <groupId>com.github.danielflower.mavenplugins.testprojects.openapi-spec-as-plugin-dependency</groupId>
+  <artifactId>openapi-spec-as-plugin-dependency-aggregator</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <modules>
+    <module>the-openapi-spec</module>
+    <module>the-service-impl</module>
+  </modules>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.danielflower.mavenplugins</groupId>
+        <artifactId>multi-module-maven-release-plugin</artifactId>
+        <version>${current.plugin.version}</version>
+        <configuration>
+          <releaseGoals>
+            <releaseGoal>install</releaseGoal>
+          </releaseGoals>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/pom.xml
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.danielflower.mavenplugins.testprojects.openapi-spec-as-plugin-dependency</groupId>
+    <artifactId>openapi-spec-as-plugin-dependency-aggregator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>the-openapi-spec</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.danielflower.mavenplugins</groupId>
+        <artifactId>multi-module-maven-release-plugin</artifactId>
+        <version>${current.plugin.version}</version>
+        <configuration>
+          <releaseGoals>
+            <releaseGoal>install</releaseGoal>
+          </releaseGoals>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/src/main/resources/openapi-spec.yaml
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/src/main/resources/openapi-spec.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.3
+info:
+  title: Openapi Spec As Plugin dependency test
+  description: |
+    Some dummy specification
+  version: 1.0.0
+  contact:
+    name: Michael Saladin
+    email: noreply@notexist.ch
+  license:
+    name: All rights reserved by multi-module-maven-release-plugin
+    url: https://github.com/danielflower/multi-module-maven-release-plugin
+servers:
+  - url: 'http://localhost:8080/api'
+tags:
+  - name: Dummy
+    description: Dummy operations
+components:
+  securitySchemes:
+    basicAuth:
+      description: |
+        No description
+      type: http
+      scheme: basic
+    bearerAuth:
+      description: |
+        No description
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+security:
+  - basicAuth: [ ]
+  - bearerAuth: [ ]
+
+paths:
+  /fee/ping:
+    get:
+      tags:
+        - Ping
+      summary: Unauthenticated ping service
+      description: Returns a ping result.
+      operationId: ping
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: 'schemas/openapi-common-types.yaml#/components/schemas/PingResult'
+        '400':
+          description: |
+            Client Error.
+          content:
+            application/json:
+              schema:
+                $ref: 'schemas/openapi-common-error-types.yaml#/components/schemas/Fault'
+        '500':
+          $ref: 'schemas/openapi-errors.yaml#/components/responses/500_Response'

--- a/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/src/main/resources/schemas/openapi-common-error-types.yaml
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/src/main/resources/schemas/openapi-common-error-types.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.3
+info:
+  title: Openapi Common Error types
+  description: 'Error types, that can be used across all applications'
+  version: 1.0.2
+  license:
+    name: All rights reserved by multi-module-maven-release-plugin
+paths: { }
+components:
+  schemas:
+    Fault:
+      description: Generic Fault.
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/Error"
+    Error:
+      description: Generic Error.
+      type: object
+      required:
+        - id
+        - status
+        - message
+      properties:
+        id:
+          description: UUID for log analyses (to trace back calls to the JFA server), should be logged by the caller
+          type: string
+        status:
+          description: The HTTP status code associated with this Error
+          type: integer
+          minimum: 100
+          maximum: 999
+        message:
+          description: Non-translated exception message, meant for logging.
+          type: string
+        code:
+          description: |
+            Optional code, to further specify the cause.
+            Possible values are to be defined per usage of the Fault.
+          type: string
+        transferId:
+          description: The transferId received in the request.
+          type: string
+        correlationId:
+          description: The correlationId received in the request.
+          type: string
+        translations:
+          description: |
+            Optional, map for translated messages, which can directly be used to show to the user (UI).
+            Key is an ISO 2 locale eg. "de", "en", "fr", "it" etc.
+          type: object
+          additionalProperties:
+            type: string
+        messageKey:
+          description: |
+            Optional, a message key to translate the error on client side (together with 'params').
+          type: string
+        params:
+          description: |
+            Optional, generic map for cases, where additional informations are to be returned.
+            Expected params are to defined per usage of the Fault.
+          type: object
+          additionalProperties:
+            type: string

--- a/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/src/main/resources/schemas/openapi-common-types.yaml
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/src/main/resources/schemas/openapi-common-types.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Openapi common types
+  description: |
+    No description
+  version: 1.0.0
+  license:
+    name: All rights reserved by multi-module-maven-release-plugin
+paths: { }
+components:
+  schemas:
+    PingResult:
+      description: |
+        Service responds with a timestamp, not meant to be parsed or used in any way.
+      type: object
+      required:
+        - timestamp
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+

--- a/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/src/main/resources/schemas/openapi-errors.yaml
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-openapi-spec/src/main/resources/schemas/openapi-errors.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: Fee Service errors
+  version: 1.0.0
+  license:
+    name: All rights reserved by multi-module-maven-release-plugin
+
+paths: { }
+
+components:
+
+  # Response-Error definitions
+  responses:
+    500_Response:
+      description: |
+        Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: 'openapi-common-error-types.yaml#/components/schemas/Fault'
+          example:
+            errors:
+              - id: '6629232743873699088'
+                status: 500
+                message: Internal server error

--- a/test-projects/openapi-spec-as-plugin-dependency/the-service-impl/pom.xml
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-service-impl/pom.xml
@@ -27,13 +27,9 @@
       <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.swagger.core.v3</groupId>
-      <artifactId>swagger-annotations</artifactId>
-      <version>2.2.20</version>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>jakarta.validation</groupId>
@@ -44,6 +40,21 @@
       <groupId>org.openapitools</groupId>
       <artifactId>jackson-databind-nullable</artifactId>
       <version>0.2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.18.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.18.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
     </dependency>
   </dependencies>
 
@@ -77,23 +88,17 @@
             </goals>
             <configuration>
               <inputSpec>openapi-spec.yaml</inputSpec>
-              <generatorName>spring</generatorName>
+              <generatorName>java</generatorName>
+              <library>native</library>
               <apiPackage>com.github.danielflower.mavenplugins.tesetprojects.openapispecasplugindependency.facade.openapi.api</apiPackage>
               <modelPackage>com.github.danielflower.mavenplugins.tesetprojects.openapispecasplugindependency.facade.openapi.model</modelPackage>
-              <generateSupportingFiles>false</generateSupportingFiles>
               <verbose>false</verbose>
               <configHelp>false</configHelp>
               <configOptions>
-                <useSpringBoot3>true</useSpringBoot3>
+                <annotationLibrary>none</annotationLibrary>
                 <dateLibrary>java8</dateLibrary>
-                <interfaceOnly>true</interfaceOnly>
-                <skipDefaultInterface>true</skipDefaultInterface>
-                <useBeanValidation>true</useBeanValidation>
-                <generateBuilders>true</generateBuilders>
-                <useEnumCaseInsensitive>true</useEnumCaseInsensitive>
-                <implicitHeaders>true</implicitHeaders>
-                <useTags>true</useTags>
-                <idea>true</idea>
+                <useBeanValidation>false</useBeanValidation>
+                <generateBuilders>false</generateBuilders>
               </configOptions>
             </configuration>
           </execution>

--- a/test-projects/openapi-spec-as-plugin-dependency/the-service-impl/pom.xml
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-service-impl/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.danielflower.mavenplugins.testprojects.openapi-spec-as-plugin-dependency</groupId>
+    <artifactId>openapi-spec-as-plugin-dependency-aggregator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>the-service-impl</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.danielflower.mavenplugins.testprojects.openapi-spec-as-plugin-dependency</groupId>
+      <artifactId>the-openapi-spec</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>2.2.20</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openapitools</groupId>
+      <artifactId>jackson-databind-nullable</artifactId>
+      <version>0.2.6</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.danielflower.mavenplugins</groupId>
+        <artifactId>multi-module-maven-release-plugin</artifactId>
+        <version>${current.plugin.version}</version>
+        <configuration>
+          <releaseGoals>
+            <releaseGoal>install</releaseGoal>
+          </releaseGoals>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.openapitools</groupId>
+        <artifactId>openapi-generator-maven-plugin</artifactId>
+        <version>7.8.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.danielflower.mavenplugins.testprojects.openapi-spec-as-plugin-dependency</groupId>
+            <artifactId>the-openapi-spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>openapi-spec.yaml</inputSpec>
+              <generatorName>spring</generatorName>
+              <apiPackage>com.github.danielflower.mavenplugins.tesetprojects.openapispecasplugindependency.facade.openapi.api</apiPackage>
+              <modelPackage>com.github.danielflower.mavenplugins.tesetprojects.openapispecasplugindependency.facade.openapi.model</modelPackage>
+              <generateSupportingFiles>false</generateSupportingFiles>
+              <verbose>false</verbose>
+              <configHelp>false</configHelp>
+              <configOptions>
+                <useSpringBoot3>true</useSpringBoot3>
+                <dateLibrary>java8</dateLibrary>
+                <interfaceOnly>true</interfaceOnly>
+                <skipDefaultInterface>true</skipDefaultInterface>
+                <useBeanValidation>true</useBeanValidation>
+                <generateBuilders>true</generateBuilders>
+                <useEnumCaseInsensitive>true</useEnumCaseInsensitive>
+                <implicitHeaders>true</implicitHeaders>
+                <useTags>true</useTags>
+                <idea>true</idea>
+              </configOptions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/test-projects/openapi-spec-as-plugin-dependency/the-service-impl/src/main/java/com/github/danielflower/mavenplugins/testprojects/openapispecasplugindependency/OpenApiController.java
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-service-impl/src/main/java/com/github/danielflower/mavenplugins/testprojects/openapispecasplugindependency/OpenApiController.java
@@ -1,0 +1,20 @@
+package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
+
+import com.github.danielflower.mavenplugins.tesetprojects.openapispecasplugindependency.facade.openapi.api.PingApi;
+import com.github.danielflower.mavenplugins.tesetprojects.openapispecasplugindependency.facade.openapi.model.PingResult;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.time.OffsetDateTime;
+import org.springframework.http.ResponseEntity;
+
+@RestController
+@RequestMapping("/api")
+public class OpenApiController implements PingApi {
+
+    @Override
+    public ResponseEntity<PingResult> ping() {
+        var result = new PingResult(OffsetDateTime.now());
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/test-projects/openapi-spec-as-plugin-dependency/the-service-impl/src/main/java/com/github/danielflower/mavenplugins/testprojects/openapispecasplugindependency/OpenApiController.java
+++ b/test-projects/openapi-spec-as-plugin-dependency/the-service-impl/src/main/java/com/github/danielflower/mavenplugins/testprojects/openapispecasplugindependency/OpenApiController.java
@@ -2,19 +2,15 @@ package com.github.danielflower.mavenplugins.testprojects.versioninheritor;
 
 import com.github.danielflower.mavenplugins.tesetprojects.openapispecasplugindependency.facade.openapi.api.PingApi;
 import com.github.danielflower.mavenplugins.tesetprojects.openapispecasplugindependency.facade.openapi.model.PingResult;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import java.time.OffsetDateTime;
-import org.springframework.http.ResponseEntity;
 
-@RestController
-@RequestMapping("/api")
-public class OpenApiController implements PingApi {
+public class OpenApiController {
 
-    @Override
-    public ResponseEntity<PingResult> ping() {
-        var result = new PingResult(OffsetDateTime.now());
-        return ResponseEntity.ok(result);
+
+    public static void main(String[] args) {
+        // Not really a controller, but at least it uses the classes PingResult
+        PingResult x = new PingResult();
     }
+
 
 }


### PR DESCRIPTION
Hi there,

as proposed in issue [145](https://github.com/danielflower/multi-module-maven-release-plugin/issues/145) here is the PR to handle Plugin dependencies.

I created a testproject called openapi-spec-as-plugin-dependency which assures that interproject-plugin dependencies are automatically adjusted in a release.

If you have any questions, let me know. I am glad to be of assistance. 

Thanks & Cheers
Michael
