### PR TITLE
Update to use minimal java version 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11 ]
+        java: [ 11 ]
     name: Java ${{ matrix.java }} build
     steps:
       - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -258,8 +258,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.9.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Hi Daniel,

here is a small PR that will make the release build again by updating the minimal version 11 instead of 8. I don't know whether this is how you want to proceed, but it would resolve the current problem with the build, and Java 8 is really old and I assume that most projects no longer use it (except legacy projects using JEE6 or JEE7).

Do you plan a release soon? The last release 3.6.4 seems to be quite old.

Thanks a lot for your input.

Best regards
Michael
