### PR TITLE
Add tagNameFormat parameter to support customized tag format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
             <artifactId>plexus-utils</artifactId>
             <version>3.6.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-interpolation</artifactId>
+            <version>1.27</version >
+        </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/com/github/danielflower/mavenplugins/release/BaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/BaseMojo.java
@@ -52,6 +52,18 @@ public abstract class BaseMojo extends AbstractMojo {
 	@Parameter(property = "buildNumber")
 	protected Long buildNumber;
 
+    /**
+     * Format to use when generating the tag name. Property interpolation is performed on the
+     * tag, but in order to ensure that the interpolation occurs during release, you must use <code>@{...}</code>
+     * to reference the properties rather than <code>${...}</code>. The following properties are available:
+     * <ul>
+     *     <li><code>groupId</code> or <code>project.groupId</code> - The groupId of the root project.
+     *     <li><code>artifactId</code> or <code>project.artifactId</code> - The artifactId of the root project.
+     *     <li><code>version</code> or <code>project.version</code> - The release version of the root project.
+     * </ul>
+     */
+    @Parameter(defaultValue = "", property = "tagNameFormat")
+    protected String tagNameFormat;
 
     /**
      * <p>

--- a/src/main/java/com/github/danielflower/mavenplugins/release/NextMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/NextMojo.java
@@ -46,7 +46,7 @@ public class NextMojo extends BaseMojo {
                 .credentialsProvider(getCredentialsProvider(log))
                 .buildFromCurrentDir();
             ResolverWrapper resolverWrapper = new ResolverWrapper(factory, artifactResolver, remoteRepositories, localRepository);
-            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction, resolverWrapper, versionNamer);
+            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction, resolverWrapper, versionNamer, tagNameFormat);
             if (reactor == null) {
                 return;
             }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleasableModule.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleasableModule.java
@@ -1,6 +1,8 @@
 package com.github.danielflower.mavenplugins.release;
 
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.utils.StringUtils;
 
 import java.util.List;
 
@@ -9,15 +11,24 @@ public class ReleasableModule {
     private final MavenProject project;
     private final VersionName version;
     private final String tagName;
+    private final String tagNameFormat;
     private final String equivalentVersion;
     private final String relativePathToModule;
 
-    public ReleasableModule(MavenProject project, VersionName version, String equivalentVersion, String relativePathToModule) {
+    public ReleasableModule(MavenProject project, VersionName version, String equivalentVersion, String relativePathToModule, String tagNameFormat, Log log) {
         this.project = project;
         this.version = version;
         this.equivalentVersion = equivalentVersion;
         this.relativePathToModule = relativePathToModule;
-        this.tagName = project.getArtifactId() + "-" + version.releaseVersion();
+
+        String defaultTagName = project.getArtifactId() + "-" + version.releaseVersion();
+        if (StringUtils.isNotEmpty(tagNameFormat)) {
+            this.tagName = AnnotatedTag.formatTagName(defaultTagName, project.getGroupId(), project.getArtifactId(), version.releaseVersion(), tagNameFormat, log);
+        } else {
+            this.tagName = defaultTagName;
+        }
+
+        this.tagNameFormat = tagNameFormat;
     }
 
     public String getTagName() {
@@ -70,7 +81,7 @@ public class ReleasableModule {
         return relativePathToModule;
     }
 
-    public ReleasableModule createReleasableVersion() {
-        return new ReleasableModule(project, version, null, relativePathToModule);
+    public ReleasableModule createReleasableVersion(Log log) {
+        return new ReleasableModule(project, version, null, relativePathToModule, tagNameFormat, log);
     }
 }

--- a/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/ReleaseMojo.java
@@ -159,7 +159,7 @@ public class ReleaseMojo extends BaseMojo {
             repo.errorIfNotClean(ignoredUntrackedPaths);
 
             ResolverWrapper resolverWrapper = new ResolverWrapper(factory, artifactResolver, remoteRepositories, localRepository);
-            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction, resolverWrapper, versionNamer);
+            Reactor reactor = Reactor.fromProjects(log, repo, project, projects, buildNumber, modulesToForceRelease, noChangesAction, resolverWrapper, versionNamer, tagNameFormat);
             if (reactor == null) {
                 return;
             }

--- a/src/test/java/com/github/danielflower/mavenplugins/release/AnnotatedTagFinderTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/AnnotatedTagFinderTest.java
@@ -26,9 +26,9 @@ public class AnnotatedTagFinderTest {
         AnnotatedTag tag1 = saveFileInModuleAndTag(project, "core-utils", "2", 0);
         AnnotatedTag tag2 = saveFileInModuleAndTag(project, "console-app", "1.2", 4);
 
-        assertThat(annotatedTagFinder.tagsForVersion(project.local, "console-app", "1.3"), hasSize(0));
-        assertThat(annotatedTagFinder.tagsForVersion(project.local, "console-app", "1.2"), contains(tag2));
-        assertThat(annotatedTagFinder.tagsForVersion(project.local, "core-utils", "2"), contains(tag1));
+        assertThat(annotatedTagFinder.tagsForVersion(project.local, "my-group", "console-app", "1.3", null, null), hasSize(0));
+        assertThat(annotatedTagFinder.tagsForVersion(project.local, "my-group", "console-app", "1.2", null, null), contains(tag2));
+        assertThat(annotatedTagFinder.tagsForVersion(project.local, "my-group", "core-utils", "2", null, null), contains(tag1));
     }
 
     static AnnotatedTag saveFileInModuleAndTag(TestProject project, String moduleName, String version, long buildNumber) throws IOException, GitAPIException {
@@ -62,7 +62,7 @@ public class AnnotatedTagFinderTest {
         AnnotatedTag tag1 = tagCurrentCommit(project, "console-app", "1.1.1", 1);
         AnnotatedTag tag3 = tagCurrentCommit(project, "console-app", "1.1.1", 3);
         AnnotatedTag tag2 = tagCurrentCommit(project, "console-app", "1.1.1", 2);
-        List<AnnotatedTag> annotatedTags = annotatedTagFinder.tagsForVersion(project.local, "console-app", "1.1.1");
+        List<AnnotatedTag> annotatedTags = annotatedTagFinder.tagsForVersion(project.local, "my-group", "console-app", "1.1.1", null, null);
         assertThat(annotatedTags, containsInAnyOrder(tag1, tag2, tag3));
     }
 
@@ -75,7 +75,7 @@ public class AnnotatedTagFinderTest {
         AnnotatedTag tag2 = saveFileInModuleAndTag(project, ".", "1.0", 1);
         project.checkoutBranch("feature");
 
-        List<AnnotatedTag> annotatedTags = annotatedTagFinder.tagsForVersion(project.local, "root", "1.0");
+        List<AnnotatedTag> annotatedTags = annotatedTagFinder.tagsForVersion(project.local, "my-group", "root", "1.0", null, null);
 
         assertThat(annotatedTags, both(contains(tag1)).and(not(contains(tag2))));
     }
@@ -94,16 +94,16 @@ public class AnnotatedTagFinderTest {
         // This should actually be implemented with a parameterized JUnit test but since this class isn't set up for
         // that yet we'll use our own data-driven harness.
         Arrays.asList(new Object[][]{
-            new Object[]{"libs-1.0.0", refPrefix + "foo-1.0.0-1", null},    // artifact ID does not match -> expect null
-            new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0-1", 1L},     // proper match with expected delimiter
-            new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0.1", null},   // no delimiter match
-            new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0@1", null},   // no delimiter match
-            new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0-A", null}    // format exception on build number
-        })
-        .forEach(dataSet -> {
-            final Object expectedBuildNumber = dataSet[2];
-            final Long buildNumber = tagFinder.buildNumberOf(dataSet[0].toString(), dataSet[1].toString());
-            assertThat(buildNumber, is(expectedBuildNumber));
-        });
+                new Object[]{"libs-1.0.0", refPrefix + "foo-1.0.0-1", null},    // artifact ID does not match -> expect null
+                new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0-1", 1L},     // proper match with expected delimiter
+                new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0.1", null},   // no delimiter match
+                new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0@1", null},   // no delimiter match
+                new Object[]{"libs-1.0.0", refPrefix + "libs-1.0.0-A", null}    // format exception on build number
+            })
+            .forEach(dataSet -> {
+                final Object expectedBuildNumber = dataSet[2];
+                final Long buildNumber = tagFinder.buildNumberOf(dataSet[0].toString(), dataSet[1].toString());
+                assertThat(buildNumber, is(expectedBuildNumber));
+            });
     }
 }

--- a/src/test/java/com/github/danielflower/mavenplugins/release/AnnotatedTagTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/AnnotatedTagTest.java
@@ -1,8 +1,11 @@
 package com.github.danielflower.mavenplugins.release;
 
+import org.apache.maven.plugin.logging.Log;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
+import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.mockito.Mockito;
 import scaffolding.TestProject;
 
 import java.io.IOException;
@@ -45,4 +48,68 @@ public class AnnotatedTagTest {
         assertThat(inflatedTag.buildNumber(), equalTo(0L));
     }
 
+    @Test
+    public void tagIsFormattedAsExpectedWithProjectPrefixTemplate() {
+        Log log = Mockito.mock(Log.class);
+        String name = "release";
+        String groupId = "my-group";
+        String artifactId = "my-app";
+        String version = "1.0.0";
+        String tagNameFormat = "@{project.groupId}-@{project.artifactId}-@{project.version}";
+        String expected = "my-group-my-app-1.0.0";
+        String result1 = AnnotatedTag.formatTagName(name, groupId, artifactId, version, tagNameFormat, log);
+        assertThat(result1, Matchers.equalTo(expected));
+    }
+
+    @Test
+    public void tagIsFormattedAsExpectedWithEmptyTemplate() {
+        Log log = Mockito.mock(Log.class);
+        String name = "release";
+        String groupId = "my-group";
+        String artifactId = "my-app";
+        String version = "1.0.0";
+        String tagNameFormat = "";
+        String expected = "";
+        String result = AnnotatedTag.formatTagName(name, groupId, artifactId, version, tagNameFormat, log);
+        assertThat(result, Matchers.equalTo(expected));
+    }
+
+    @Test
+    public void tagIsFormattedAsExpectedWith0nlyVersionTemplate() {
+        Log log = Mockito.mock(Log.class);
+        String name = "release";
+        String groupId = "my-group";
+        String artifactId = "my-app";
+        String version = "1.0.0";
+        String tagNameFormat = "@{version}";
+        String expected = "1.0.0";
+        String result = AnnotatedTag.formatTagName(name, groupId, artifactId, version, tagNameFormat, log);
+        assertThat(result, Matchers.equalTo(expected));
+    }
+
+    @Test
+    public void testWithNullTemplate() {
+        Log log = Mockito.mock(Log.class);
+        String name = "release";
+        String groupId = "my-group";
+        String artifactId = "my-app";
+        String version = "1.0.0";
+        String tagNameFormat = null;
+        String expected = "";
+        String result = AnnotatedTag.formatTagName(name, groupId, artifactId, version, tagNameFormat, log);
+        assertThat(result, Matchers.equalTo(expected));
+    }
+
+    @Test
+    public void testWithInvalidTemplate() {
+        Log log = Mockito.mock(Log.class);
+        String name = " release ";
+        String groupId = "my-group";
+        String artifactId = "my-app";
+        String version = "1.0.0";
+        String tagNameFormat = "@{$";
+        String expected = "@{$";
+        String result = AnnotatedTag.formatTagName(name, groupId, artifactId, version, tagNameFormat, log);
+        assertThat(result, Matchers.equalTo(expected));
+    }
 }

--- a/src/test/java/com/github/danielflower/mavenplugins/release/ReleasableModuleTest.java
+++ b/src/test/java/com/github/danielflower/mavenplugins/release/ReleasableModuleTest.java
@@ -25,11 +25,11 @@ public class ReleasableModuleTest {
         project.setArtifactId("some-arty");
         project.setGroupId("some-group");
         ReleasableModule first = new ReleasableModule(
-            project, new VersionName("1.2.3-SNAPSHOT", "1.2.3", 12), "1.2.3.11", "somewhere"
+            project, new VersionName("1.2.3-SNAPSHOT", "1.2.3", 12), "1.2.3.11", "somewhere", null, null
         );
         assertThat(first.willBeReleased(), is(false));
 
-        ReleasableModule changed = first.createReleasableVersion();
+        ReleasableModule changed = first.createReleasableVersion(null);
         assertThat(changed.getArtifactId(), equalTo("some-arty"));
         assertThat(changed.getBuildNumber(), equalTo(12L));
         assertThat(changed.getGroupId(), equalTo("some-group"));

--- a/src/test/java/e2e/VersionOnlyTagTest.java
+++ b/src/test/java/e2e/VersionOnlyTagTest.java
@@ -1,0 +1,117 @@
+package e2e;
+
+import com.github.danielflower.mavenplugins.release.AnnotatedTag;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scaffolding.MvnRunner;
+import scaffolding.TestProject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static scaffolding.ExactCountMatcher.oneOf;
+import static scaffolding.GitMatchers.hasCleanWorkingDirectory;
+import static scaffolding.GitMatchers.hasTag;
+
+public class VersionOnlyTagTest {
+
+    final String buildNumber = String.valueOf(System.currentTimeMillis());
+    final String expected = "2.0." + buildNumber;
+    final TestProject testProject = TestProject.versionOnlyTagProject();
+
+    @BeforeClass
+    public static void installPluginToLocalRepo() throws MavenInvocationException {
+        MvnRunner.installReleasePluginToLocalRepo();
+    }
+
+    @Test
+    public void canUpdateSnapshotVersionToReleaseVersionAndInstallToLocalRepo() throws Exception {
+        List<String> outputLines = testProject.mvnRelease(buildNumber);
+        assertThat(outputLines, oneOf(containsString("Going to release version-only-tag " + expected)));
+        assertThat(outputLines, oneOf(containsString("Hello from version " + expected + "!")));
+
+        MvnRunner.assertArtifactInLocalRepo("com.github.danielflower.mavenplugins.testprojects", "version-only-tag", expected);
+
+        assertThat(new File(testProject.localDir, "target/version-only-tag-" + expected + "-package.jar").exists(), is(true));
+    }
+
+    @Test
+    public void theBuildNumberIsOptionalAndWillStartAt0AndThenIncrementTakingIntoAccountLocalAndRemoteTags() throws IOException, GitAPIException {
+        testProject.mvn("releaser:release");
+        assertThat(testProject.local, hasTag("2.0.0"));
+        testProject.mvn("releaser:release");
+        assertThat(testProject.local, hasTag("2.0.1"));
+
+        AnnotatedTag.create("2.0.2", "2.0", 2).saveAtHEAD(testProject.local);
+        testProject.mvn("releaser:release");
+        assertThat(testProject.local, hasTag("2.0.3"));
+
+        AnnotatedTag.create("2.0.4", "2.0", 4).saveAtHEAD(testProject.origin);
+        AnnotatedTag.create("unrelated-module-2.0.5", "2.0", 5).saveAtHEAD(testProject.origin);
+        testProject.mvn("releaser:release");
+        assertThat(testProject.local, hasTag("2.0.5"));
+
+    }
+
+    @Test
+    public void theLocalAndRemoteGitReposAreTaggedWithTheModuleNameAndVersion() throws IOException, InterruptedException {
+        testProject.mvnRelease(buildNumber);
+        String expectedTag = expected;
+        assertThat(testProject.local, hasTag(expectedTag));
+        assertThat(testProject.origin, hasTag(expectedTag));
+    }
+
+    @Test
+    public void onlyLocalGitRepoIsTaggedWithTheModuleNameAndVersionWithoutPush() throws IOException, InterruptedException {
+        testProject.mvn("-DbuildNumber=" + buildNumber,
+                "-Dpush=false",
+                "releaser:release");
+        String expectedTag = expected;
+        assertThat(testProject.local, hasTag(expectedTag));
+        assertThat(testProject.origin, not(hasTag(expectedTag)));
+    }
+
+    @Test
+    public void thePomChangesAreRevertedAfterTheRelease() throws IOException, InterruptedException {
+        ObjectId originHeadAtStart = head(testProject.origin);
+        ObjectId localHeadAtStart = head(testProject.local);
+        assertThat(originHeadAtStart, equalTo(localHeadAtStart));
+        testProject.mvnRelease(buildNumber);
+        assertThat(head(testProject.origin), equalTo(originHeadAtStart));
+        assertThat(head(testProject.local), equalTo(localHeadAtStart));
+        assertThat(testProject.local, hasCleanWorkingDirectory());
+        assertThat(FileUtils.readFileToString(new File(testProject.localDir, "pom.xml"), StandardCharsets.UTF_8),
+            containsString("<!-- This comment is here for a test that ensures comments are not deleted -->"));
+    }
+
+    private ObjectId head(Git git) throws IOException {
+        return git.getRepository().getRefDatabase().findRef("HEAD").getObjectId();
+    }
+
+    @Test
+    public void originTagsNotConsultedWithoutPull() throws Exception {
+        testProject.mvn("releaser:release");
+
+        AnnotatedTag.create("2.0.2", "2.0", 2).saveAtHEAD(testProject.local);
+        AnnotatedTag.create("2.0.5", "2.0", 5).saveAtHEAD(testProject.origin);
+
+        testProject.mvn("-Dpush=false",
+                        "-Dpull=false",
+                        "releaser:release");
+        assertThat(testProject.local, hasTag("2.0.3"));
+        assertThat(testProject.origin, not(hasTag("2.0.3")));
+    }
+
+}

--- a/src/test/java/scaffolding/ReleasableModuleBuilder.java
+++ b/src/test/java/scaffolding/ReleasableModuleBuilder.java
@@ -44,7 +44,7 @@ public class ReleasableModuleBuilder {
     }
 
     public ReleasableModule build() throws ValidationException {
-        return new ReleasableModule(project, versionNamer.name(project.getVersion(), buildNumber, null), equivalentVersion, relativePathToModule);
+        return new ReleasableModule(project, versionNamer.name(project.getVersion(), buildNumber, null), equivalentVersion, relativePathToModule, null,  null);
     }
 
     public static ReleasableModuleBuilder aModule() {

--- a/src/test/java/scaffolding/TestProject.java
+++ b/src/test/java/scaffolding/TestProject.java
@@ -204,6 +204,10 @@ public class TestProject {
         return project("different-delimiter");
     }
 
+    public static TestProject versionOnlyTagProject() {
+        return project("version-only-tag");
+    }
+
     public void setMvnRunner(MvnRunner mvnRunner) {
         this.mvnRunner = mvnRunner;
     }

--- a/test-projects/version-only-tag/.gitignore
+++ b/test-projects/version-only-tag/.gitignore
@@ -1,0 +1,6 @@
+target
+.idea/
+*.iml
+.classpath
+.settings
+.project

--- a/test-projects/version-only-tag/assembly-descriptor.xml
+++ b/test-projects/version-only-tag/assembly-descriptor.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <!-- TODO: a jarjar format would be better -->
+    <id>package</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/test-projects/version-only-tag/pom.xml
+++ b/test-projects/version-only-tag/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.danielflower.mavenplugins.testprojects</groupId>
+    <artifactId>version-only-tag</artifactId>
+    <version>2.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    <!-- This comment is here for a test that ensures comments are not deleted -->
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.danielflower.mavenplugins</groupId>
+                <artifactId>multi-module-maven-release-plugin</artifactId>
+                <version>${current.plugin.version}</version>
+                <configuration>
+                    <releaseGoals>
+                        <releaseGoal>install</releaseGoal>
+                    </releaseGoals>
+                    <tagNameFormat>@{version}</tagNameFormat>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.google.code.echo-maven-plugin</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <message>Hello from version ${project.version}!</message>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>echo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>assembly-descriptor.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <!-- This project is used by MavenCompatibilityTest.java where old versions of maven
+     that default to http (rather than https) are used. Maven central now blocks non-https
+      requests so the following just forces all maven versions to use https. -->
+    <distributionManagement>
+        <repository>
+            <id>Central Maven repository</id>
+            <name>Central Maven repository https</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+    </distributionManagement>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>Central Maven repository</id>
+            <name>Central Maven repository https</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/test-projects/version-only-tag/src/main/java/com/github/danielflower/mavenplugins/testproject/singlepom/Main.java
+++ b/test-projects/version-only-tag/src/main/java/com/github/danielflower/mavenplugins/testproject/singlepom/Main.java
@@ -1,0 +1,7 @@
+package com.github.danielflower.mavenplugins.testproject.singlepom;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world");
+    }
+}


### PR DESCRIPTION
Add tagNameFormat parameter to support customized tag format and add related UT and e2e test cases.
The default value for the tagNameFormat parameter is empty and in such case, the tag behavior is still same as before, the tag name is still in {artifactId}-{version} format.