### PR TITLE
Refine the release version log when there is no change since last release

### DIFF
--- a/src/test/java/e2e/NextMojoTest.java
+++ b/src/test/java/e2e/NextMojoTest.java
@@ -65,12 +65,12 @@ public class NextMojoTest {
         assertTagDoesNotExist("more-utils-10.0.2");
         assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
 
-        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for parent-module as it has not been changed since that release.")));
-        assertThat(output, oneOf(containsString("[INFO] Will use version 10.0.1 for more-utils as it has not been changed since that release.")));
-        assertThat(output, oneOf(containsString("[INFO] Will use version 2.0.1 for core-utils as it has not been changed since that release.")));
-        assertThat(output, oneOf(containsString("[INFO] Will use version 3.2.1 for console-app as it has not been changed since that release.")));
-        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for deep-dependencies-aggregator as it has not been changed since that release.")));
         assertThat(output, oneOf(containsString("[WARNING] No changes have been detected in any modules so will re-release them all")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.2 for parent-module as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 10.0.2 for more-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 2.0.2 for core-utils as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 3.2.2 for console-app as it has not been changed since that release.")));
+        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.2 for deep-dependencies-aggregator as it has not been changed since that release.")));
     }
 
     @Test
@@ -86,11 +86,6 @@ public class NextMojoTest {
         assertTagDoesNotExist("more-utils-10.0.2");
         assertTagDoesNotExist("deep-dependencies-aggregator-1.0.2");
 
-        assertThat(output, oneOf(containsString("[INFO] Will use version 1.2.3.1 for parent-module as it has not been changed since that release.")));
-        assertThat(output, oneOf(containsString("[INFO] Will use version 10.0.1 for more-utils as it has not been changed since that release.")));
-        assertThat(output, oneOf(containsString("[INFO] Will use version 2.0.1 for core-utils as it has not been changed since that release.")));
-        assertThat(output, oneOf(containsString("[INFO] Will use version 3.2.1 for console-app as it has not been changed since that release.")));
-        assertThat(output, oneOf(containsString("[INFO] Will use version 1.0.1 for deep-dependencies-aggregator as it has not been changed since that release.")));
         assertThat(output, oneOf(containsString("[WARNING] No changes have been detected in any modules so will not perform release")));
     }
 

--- a/src/test/java/e2e/SkippingUnchangedModulesTest.java
+++ b/src/test/java/e2e/SkippingUnchangedModulesTest.java
@@ -68,13 +68,19 @@ public class SkippingUnchangedModulesTest {
         List<String> firstBuildOutput = testProject.mvnRelease("1");
         assertThat(firstBuildOutput, noneOf(containsString("No changes have been detected in any modules so will re-release them all")));
         List<String> secondBuildOutput = testProject.mvnRelease("2");
-        assertThat(secondBuildOutput, oneOf(containsString("No changes have been detected in any modules so will re-release them all")));
 
         assertTagExists("console-app-3.2.2");
         assertTagExists("parent-module-1.2.3.2");
         assertTagExists("core-utils-2.0.2");
         assertTagExists("more-utils-10.0.2");
         assertTagExists("deep-dependencies-aggregator-1.0.2");
+
+        assertThat(secondBuildOutput, oneOf(containsString("[WARNING] No changes have been detected in any modules so will re-release them all")));
+        assertThat(secondBuildOutput, oneOf(containsString("[INFO] Will use version 1.2.3.2 for parent-module as it has not been changed since that release.")));
+        assertThat(secondBuildOutput, oneOf(containsString("[INFO] Will use version 10.0.2 for more-utils as it has not been changed since that release.")));
+        assertThat(secondBuildOutput, oneOf(containsString("[INFO] Will use version 2.0.2 for core-utils as it has not been changed since that release.")));
+        assertThat(secondBuildOutput, oneOf(containsString("[INFO] Will use version 3.2.2 for console-app as it has not been changed since that release.")));
+        assertThat(secondBuildOutput, oneOf(containsString("[INFO] Will use version 1.0.2 for deep-dependencies-aggregator as it has not been changed since that release.")));
     }
 
     @Test


### PR DESCRIPTION
The change is for refine the release version log when there is no change since last release:
1. When "noChangesAction" parameter is ReleaseAll, also there is no change since last release, the release version log should contain the new version since all modules will be built as new version.
2. When "noChangesAction" parameter is ReleaseNone or FailBuild, also there is no change since last release, there should be no release version log since there will be no build.